### PR TITLE
Automatic spelling checks

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = .git

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,21 @@
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # fu_arduino_sensors
+
 Code for Arduino Sensors
+
+## Spelling
+
+The code is checked for spelling mistakes (happens more often that one might expect). It happens automatically on push to main or when a PR is created.
+
+If you want to run this locally:
+
+```bash
+pip install codespell
+codespell                   # to check for misspellings
+codespell --write-changes   # to automatically fix misspellings
+```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,7 +197,7 @@ float getTempWet()
 
 float getFlow()
 /* From YF-S201 manual:
-   Pluse Characteristic:F=7Q(L/MIN).
+   Pulse Characteristic:F=7Q(L/MIN).
    2L/MIN=16HZ 4L/MIN=32.5HZ 6L/MIN=49.3HZ 8L/MIN=65.5HZ 10L/MIN=82HZ
    sample_window is in milli seconds, so hz is pulseCount * 1000 / SAMPLE_WINDOW
  */


### PR DESCRIPTION
This adds automatic spelling checks on push to main and on PRs. It happens a few more times than most can admit. This way, we can catch them a bit earlier especially as we add docs to this.