### PR TITLE
Use build flags to centrally choose sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,35 @@
-# fu_arduino_sensors
+# Farm Urban (Arduino Sensors)
 
 Code for Arduino Sensors
+
+This code is built for the [Arduino UNO Wifi R2](https://store.arduino.cc/products/arduino-uno-wifi-rev2). Other boards might be added with time, if need be. However, should you need to test on another board, [supported by PlatformIO](https://docs.platformio.org/en/latest/boards/index.html), the easiest way would be to add a new environment in the [platformio.ini](./platformio.ini) file. The current code base is built to work with Arduino which means choosing boards [supported by the Arduino platform](https://docs.platformio.org/en/latest/frameworks/arduino.html#boards) is easier.
+
+## Sensors
+
+There are a number of sensors used in the farm for different purposes.
+
+|Sensor|Purpose|Pin|Flag|Macro|
+|--|--|--|--|--|
+|Light||A0|SENSORS_LIGHT_PIN|HAVE_LIGHT|
+|C02||A1|SENSORS_CO2_PIN|HAVE_CO2|
+|EC||A2|SENSORS_EC_PIN|HAVE_EC|
+|PH||A3|SENSORS_PH_PIN|HAVE_PH|
+|Moisture||A4|SENSORS_MOISTURE_PIN|HAVE_MOISTURE|
+|DH22|Humidity and Temperature (Air)|2|SENSORS_DHT22_PIN|HAVE_TEMP_HUMIDITY|
+|SEN0217|Flow Sensor|3|SENSORS_SEN0217_PIN|HAVE_FLOW|
+|DS18S20|Temperature (Wet)|4|SENSORS_DS18S20_PIN|HAVE_TEMP_WET|
+
+When you start using this, you might not have/need all of these. You can remove the ones you do not have/need by editing `build_flags` in [platformio.ini](./platformio.ini). For example, if you do not have PH sensor, you can remove the line containing `-DSENSORS_PH_PIN=A3`. By default, when a sensor is not enabled, the value is `-1` to signify invalid.
+
+> [!IMPORTANT]
+> The EC and PH probes may require calibration. The values are stored in EEPROM (otherwise referred to as KeyValue store). This code may be added to the code base at a later time but in the mean time you can have a look at [logic here](https://github.com/farm-urban/fufarm_rpi_arduino_shield).
+>
+> The EC and PH probes require temperature compensation. The best value to use for this is the wet temperature. However, if the wet temperature sensor is not configured, the air temperature is used which may not be as accurate. A build time warning is produced.
+> The air temperature may also used if the wet temperature reading is between -1000 and -1002, limits inclusive which is usually transient.
+
+## Data Transmission
+
+The code base supports either sending data to an InfluxDB server or Home Assistant (MQTT). These are controlled by the `USE_INFLUXDB` and `USE_HOME_ASSISTANT` constants which must be set to `1` to enable.
 
 ## Spelling
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,6 @@ platform = atmelmegaavr
 board = uno_wifi_rev2
 framework = arduino
 lib_deps = 
-	SPI
 	arduino-libraries/WiFiNINA @ ^1.8.13
 	beegee-tokyo/DHT sensor library for ESPx @ ^1.18
 	paulstoffregen/OneWire @ ^2.3.5
@@ -21,6 +20,17 @@ lib_deps =
 	https://github.com/linucks/DFRobot_PH
 	pubsubclient
 	bblanchon/ArduinoJson @ ^6.21.3
+build_flags = 
+	-DSENSORS_LIGHT_PIN=A0
+	-DSENSORS_CO2_PIN=A1
+	-DSENSORS_EC_PIN=A2
+	-DSENSORS_PH_PIN=A3
+	-DSENSORS_MOISTURE_PIN=A4
+	-DSENSORS_DHT22_PIN=2
+	-DSENSORS_SEN0217_PIN=3
+	-DSENSORS_DS18S20_PIN=4
+	-DUSE_INFLUXDB=0
+	-DUSE_HOME_ASSISTANT=1
 
 ; To be restored once we actually create tests
 ; [env:native]

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,75 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#ifdef SENSORS_LIGHT_PIN
+  #define HAVE_LIGHT
+#endif
+
+#ifdef SENSORS_CO2_PIN
+  #define HAVE_CO2
+#endif
+
+#ifdef SENSORS_EC_PIN
+  #define HAVE_EC
+#endif
+
+#ifdef SENSORS_PH_PIN
+  #define HAVE_PH
+#endif
+
+#ifdef SENSORS_MOISTURE_PIN
+  #define HAVE_MOISTURE
+#endif
+
+#ifdef SENSORS_DHT22_PIN
+  #define HAVE_TEMP_HUMIDITY
+
+  // ensure only digital pins configured
+  #ifdef ARDUINO
+    #if SENSORS_DHT22_PIN < 0 || SENSORS_DHT22_PIN > 13
+      #error "Pin configured for DHT22 must a digital one.")
+    #endif
+  #else // any other board we have not validated
+    #pragma message "⚠️ Unable to validate if pin configured for SEN0217 (flow sensor) allows interrupts required."
+  #endif
+#endif
+
+#ifdef SENSORS_SEN0217_PIN
+  #define HAVE_FLOW
+
+  // For this flow sensor, only interrupt pins should be used. Configured on a rising edge
+  // https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/
+  // In case, that does not work, try the other another language via:
+  // https://www.arduino.cc/reference/cs/language/functions/external-interrupts/attachinterrupt/
+
+  #ifdef ARDUINO_AVR_UNO_WIFI_REV2
+    #if SENSORS_SEN0217_PIN < 0 || SENSORS_SEN0217_PIN > 13
+      #error "Pin configured for SEN0217 (flow sensor) must support interrupts.")
+    #endif
+  #else // any other board we have not validated
+    #pragma message "⚠️ Unable to validate if pin configured for SEN0217 (flow sensor) allows interrupts required."
+  #endif
+#endif
+
+#ifdef SENSORS_DS18S20_PIN
+  #define HAVE_TEMP_WET
+#endif
+
+#ifndef USE_INFLUXDB
+  #define USE_INFLUXDB 0
+#endif
+
+#ifndef USE_HOME_ASSISTANT
+  #define USE_HOME_ASSISTANT 0
+#endif
+
+// Validation of the build configuration
+#if !defined(HAVE_TEMP_HUMIDITY) && (USE_INFLUXDB == 1)
+  #error "Temperature and Humidity sensor must be setup when using influxdb directly
+#endif
+
+#ifndef HAVE_TEMP_WET
+  #pragma message "⚠️ Without DS18S20 (wet temperature), calibration or EC and PH sensors is done using air temperature which may not be as accurate!"
+#endif
+
+#endif // CONFIG_H

--- a/src/config.h
+++ b/src/config.h
@@ -27,10 +27,10 @@
   // ensure only digital pins configured
   #ifdef ARDUINO
     #if SENSORS_DHT22_PIN < 0 || SENSORS_DHT22_PIN > 13
-      #error "Pin configured for DHT22 must a digital one.")
+      #error "Pin configured for DHT22 must a digital one."
     #endif
   #else // any other board we have not validated
-    #pragma message "⚠️ Unable to validate if pin configured for SEN0217 (flow sensor) allows interrupts required."
+    #pragma message "⚠️ Unable to validate pin configured for DHT22."
   #endif
 #endif
 
@@ -44,7 +44,7 @@
 
   #ifdef ARDUINO_AVR_UNO_WIFI_REV2
     #if SENSORS_SEN0217_PIN < 0 || SENSORS_SEN0217_PIN > 13
-      #error "Pin configured for SEN0217 (flow sensor) must support interrupts.")
+      #error "Pin configured for SEN0217 (flow sensor) must support interrupts."
     #endif
   #else // any other board we have not validated
     #pragma message "⚠️ Unable to validate if pin configured for SEN0217 (flow sensor) allows interrupts required."
@@ -65,7 +65,7 @@
 
 // Validation of the build configuration
 #if !defined(HAVE_TEMP_HUMIDITY) && (USE_INFLUXDB == 1)
-  #error "Temperature and Humidity sensor must be setup when using influxdb directly
+  #error "Temperature and Humidity sensor must be setup when using InfluxDB directly
 #endif
 
 #ifndef HAVE_TEMP_WET


### PR DESCRIPTION
Most sensors are optional except for the humidity and air temperature. To make it easier to choose the sensors in use, this PR adds build flags which also have the pin numbers for each sensor and instructions on how to set them. By default, when a sensor is not enabled, the value is `-1` to signify invalid.

Sometimes one might make a mistake and choose the wrong pin for a sensor or not configure a sensor that is required. A new `config.h` file validates the configuration.

Also removed the SPI library because it is inbuilt in the framework.