### PR TITLE
Automatic updates via PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'monthly'
+      time: '02:00'

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -1,0 +1,18 @@
+name: PlatformIO Updates
+
+on:
+  schedule:
+    - cron: '0 2 2 * *' # Runs at 01:00 on the second day of the month
+  workflow_dispatch:
+
+jobs:
+  Updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update
+        uses: peterus/platformio_dependabot@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Setup dependabot to update GitHub Workflow files and a custom action workflow to keep PlatformIO dependencies up to date.

This logic will create pull requests on the first/second day of the month. Merging them is optional. Pull Requests will trigger CI which means we can test before merging.

I have not setup any assignees but that can be done another day.