### PR TITLE
Move sensor setup and reading logic to separate files

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -1,6 +1,15 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+// #define MOCK ; // Uncomment to skip wifi connection for testing sensors
+
+#ifdef MOCK
+#define SAMPLE_WINDOW 5000
+#else
+// Time in milliseconds - 5 minutes = 1000 * 60 * 5 = 300000
+#define SAMPLE_WINDOW 60000
+#endif
+
 #ifdef SENSORS_LIGHT_PIN
   #define HAVE_LIGHT
 #endif

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -1,0 +1,211 @@
+#include "sensors.h"
+#include <Arduino.h>
+
+// Will be different depending on the reference voltage
+#define ANALOG_REFERENCE_MILLI_VOLTS 5000
+#define ANALOG_MAX_VALUE 1024 // 10 bit ADC
+// to avoid possible loss of precision, multiply before dividing
+#define ANALOG_READ_MILLI_VOLTS(pin) ((analogRead(pin) * ANALOG_REFERENCE_MILLI_VOLTS) / ANALOG_MAX_VALUE)
+
+FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)() = nullptr)
+{
+}
+
+FuFarmSensors::~FuFarmSensors()
+{
+}
+
+void FuFarmSensors::begin()
+{
+  dht.setup(SENSORS_DHT22_PIN, DHTesp::DHT22);
+
+#ifdef HAVE_FLOW
+  pulseCount = 0;
+  if (sen0217InterruptHandler != nullptr)
+  {
+    attachInterrupt(digitalPinToInterrupt(SENSORS_SEN0217_PIN), sen0217InterruptHandler, RISING);
+  }
+#endif
+
+#ifdef HAVE_EC
+  ecProbe.begin();
+#endif
+
+#ifdef HAVE_PH
+  phProbe.begin();
+#endif
+
+#ifdef HAVE_TEMP_WET
+  ds.begin(SENSORS_DS18S20_PIN); // Wet temperature chip i/o
+#endif
+}
+
+void FuFarmSensors::calibration()
+{
+  // TODO: implement calibration (maybe based on a button?)
+  // phProbe.calibration(...);
+  // ecProbe.calibration(...);
+}
+
+void FuFarmSensors::read(FuFarmSensorsData *dest)
+{
+  dest->light = readLight();
+
+  TempAndHumidity th = dht.getTempAndHumidity();
+  float airTemperature = dest->temperature.air = th.temperature;
+  dest->humidity = th.humidity;
+
+  dest->flow = readFlow();
+  dest->co2 = readCO2();
+
+  float calibrationTemperature = airTemperature;
+#ifdef HAVE_TEMP_WET
+  float wetTemperature = dest->temperature.wet = readTempWet();
+  calibrationTemperature = wetTemperature;
+  if (wetTemperature == -1000 || wetTemperature == -1001 || wetTemperature == -1002)
+  {
+    calibrationTemperature = airTemperature;
+  }
+#endif
+
+  dest->ec = readEC(calibrationTemperature);
+  dest->ph = readPH(calibrationTemperature);
+  dest->moisture = readMoisture();
+}
+
+void FuFarmSensors::sen0217Interrupt()
+{
+  pulseCount += 1;
+}
+
+int FuFarmSensors::readLight()
+{
+#ifdef HAVE_LIGHT
+  float voltage = ANALOG_READ_MILLI_VOLTS(SENSORS_LIGHT_PIN);
+  return (int)(voltage / 10.0);
+#else
+  return -1;
+#endif
+}
+
+int FuFarmSensors::readCO2()
+{
+#ifdef HAVE_CO2
+  // Calculate CO2 concentration in ppm
+  float voltage = ANALOG_READ_MILLI_VOLTS(SENSORS_CO2_PIN);
+  if (voltage == 0.0)
+    return -1.0; // Error
+  else if (voltage < 400.0)
+    return -2.0; // Preheating
+  else
+  {
+    float voltage_difference = voltage - 400.0;
+    return (int)(voltage_difference * 50.0 / 16.0);
+  }
+#else
+  return -1;
+#endif
+}
+
+float FuFarmSensors::readEC(float temperature)
+{
+#ifdef HAVE_EC
+  float voltage = ANALOG_READ_MILLI_VOLTS(SENSORS_EC_PIN);
+  return ecProbe.readEC(voltage, temperature);
+#else
+  return -1;
+#endif
+}
+
+float FuFarmSensors::readPH(float temperature)
+{
+#ifdef HAVE_PH
+  float voltage = ANALOG_READ_MILLI_VOLTS(SENSORS_PH_PIN);
+  return phProbe.readPH(voltage, temperature);
+#else
+  return -1;
+#endif
+}
+
+float FuFarmSensors::readFlow()
+{
+#ifdef HAVE_FLOW
+  /*
+   * From YF-S201 manual:
+   * Pulse Characteristic:F=7Q(L/MIN).
+   * 2L/MIN=16HZ 4L/MIN=32.5HZ 6L/MIN=49.3HZ 8L/MIN=65.5HZ 10L/MIN=82HZ
+   * sample_window is in milli seconds, so hz is pulseCount * 1000 / SAMPLE_WINDOW
+   * */
+  float hertz = (float)(pulseCount * 1000.0) / SAMPLE_WINDOW;
+  pulseCount = 0; // reset flow counter
+  return hertz / 7.0;
+#else
+  return -1;
+#endif
+}
+
+int FuFarmSensors::readMoisture()
+{
+#ifdef HAVE_MOISTURE
+  // Need to calibrate this
+  int dry = 587;
+  int wet = 84;
+  int reading = analogRead(SENSORS_MOISTURE_PIN);
+  return (int)(100.0 * (dry - reading) / (dry - wet));
+#else
+  return -1;
+#endif
+}
+
+float FuFarmSensors::readTempWet()
+{
+#ifdef HAVE_TEMP_WET
+  // returns the temperature from one DS18S20 in DEG Celsius
+  byte data[12];
+  byte addr[8];
+
+  if (!ds.search(addr))
+  {
+    // no more sensors on chain, reset search
+    ds.reset_search();
+    return -1000;
+  }
+
+  if (OneWire::crc8(addr, 7) != addr[7])
+  {
+    // Serial.println("CRC is not valid!");
+    return -1001;
+  }
+
+  if (addr[0] != 0x10 && addr[0] != 0x28)
+  {
+    // Serial.print("Device is not recognized");
+    return -1002;
+  }
+
+  ds.reset();
+  ds.select(addr);
+  ds.write(0x44, 1); // start conversion, with parasite power on at the end
+
+  byte present = ds.reset();
+  ds.select(addr);
+  ds.write(0xBE); // Read Scratchpad
+
+  for (int i = 0; i < 9; i++)
+  { // we need 9 bytes
+    data[i] = ds.read();
+  }
+
+  ds.reset_search();
+
+  byte MSB = data[1];
+  byte LSB = data[0];
+
+  float tempRead = ((MSB << 8) | LSB); // using two's compliment
+  float TemperatureSum = tempRead / 16;
+
+  return TemperatureSum;
+#else
+  return -1;
+#endif
+}

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -1,0 +1,62 @@
+#include <DFRobot_EC.h>
+#include <DFRobot_PH.h>
+#include <DHTesp.h>
+#include <OneWire.h>
+
+#include "config.h"
+
+struct FuFarmSensorsData {
+  int light;
+  float humidity;
+  float flow;
+  int co2;
+  struct FuFarmSensorsTemperature {
+    float air;
+    float wet;
+  } temperature;
+  float ec;
+  float ph;
+  int moisture;
+};
+
+class FuFarmSensors
+{
+public:
+  FuFarmSensors(void (*sen0217InterruptHandler)() = nullptr);
+  ~FuFarmSensors();
+  void begin();                       // initialization
+  void calibration();                 // calibration
+  void read(FuFarmSensorsData* dest); // read all sensor data
+  void sen0217Interrupt();            // should be called from the interrupt handler for SEN0217 passed in the constructor
+
+private:
+#ifdef HAVE_TEMP_HUMIDITY
+  DHTesp dht; // Temperature and Humidity
+#endif
+
+#ifdef HAVE_TEMP_WET
+  OneWire ds; // Wet temperature chip i/o
+#endif
+
+#ifdef HAVE_EC
+  DFRobot_EC ecProbe; // EC probe
+#endif
+
+#ifdef HAVE_PH
+  DFRobot_PH phProbe; // pH probe
+#endif
+
+#ifdef HAVE_FLOW
+  volatile int pulseCount; // Flow Sensor
+  void (*sen0217InterruptHandler)();
+#endif
+
+private:
+  int readLight();
+  int readCO2();
+  float readEC(float temperature);
+  float readPH(float temperature);
+  float readFlow();
+  int readMoisture();
+  float readTempWet();
+};


### PR DESCRIPTION
Moving most of the logic for sensors to separate files/module to keep the main.cpp file easy to manage/maintain. With this it should be easier/faster to add support for other sensors without the burden of scrolling up and down the main.cpp file. It could also allow for supporting other OSS frameworks if need be.

The new `FuFarmSensorsData` struct allows for new data to be added without extra method arguments when transmitting. The new `FuFarmSensors` centralizes the reading of data into one function. It also creates room to handle calibration when the logic is ready to be added from the sister repository.