### PR TITLE
Add support for Arduino Leonardo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,22 +43,24 @@ jobs:
       - name: Install PlatformIO
         run: pip install --upgrade platformio
 
-      - name: Build Project
-        run: pio run --environment uno_wifi_rev2
+      - name: Build Project (default environments)
+        run: pio run
 
       # To be restored once we have a automated tests
       # - name: Run Unit Tests
       #   run: pio test --environment native
 
-      - name: Create drop folder
+      - name: Create firmware folder
         run: |
-          mkdir -p drop
-          cp ${{ github.workspace }}/.pio/build/uno_wifi_rev2/firmware.elf ${{ github.workspace }}/drop/firmware.elf
-          cp ${{ github.workspace }}/.pio/build/uno_wifi_rev2/firmware.hex ${{ github.workspace }}/drop/firmware.hex
+          mkdir -p firmware
+          cp ${{ github.workspace }}/.pio/build/leonardo/firmware.elf ${{ github.workspace }}/firmware/leonardo.elf
+          cp ${{ github.workspace }}/.pio/build/leonardo/firmware.hex ${{ github.workspace }}/firmware/leonardo.hex
+          cp ${{ github.workspace }}/.pio/build/uno_wifi_rev2/firmware.elf ${{ github.workspace }}/firmware/uno_wifi_rev2.elf
+          cp ${{ github.workspace }}/.pio/build/uno_wifi_rev2/firmware.hex ${{ github.workspace }}/firmware/uno_wifi_rev2.hex
 
-      - name: Upload Artifact (drop)
+      - name: Upload Artifact (firmware)
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ github.workspace }}/drop/*
-          name: drop
+          path: ${{ github.workspace }}/firmware/*
+          name: firmware
           retention-days: 1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 Code for Arduino Sensors
 
-This code is built for the [Arduino UNO Wifi R2](https://store.arduino.cc/products/arduino-uno-wifi-rev2). Other boards might be added with time, if need be. However, should you need to test on another board, [supported by PlatformIO](https://docs.platformio.org/en/latest/boards/index.html), the easiest way would be to add a new environment in the [platformio.ini](./platformio.ini) file. The current code base is built to work with Arduino which means choosing boards [supported by the Arduino platform](https://docs.platformio.org/en/latest/frameworks/arduino.html#boards) is easier.
+This code is built for the [Arduino UNO Wifi R2](https://store.arduino.cc/products/arduino-uno-wifi-rev2) and the [Arduino Leonardo](https://store.arduino.cc/products/arduino-leonardo-with-headers). Other boards might be added with time, if need be. However, should you need to test on another board, [supported by PlatformIO](https://docs.platformio.org/en/latest/boards/index.html), the easiest way would be to add a new environment in the [platformio.ini](./platformio.ini) file. The current code base is built to work with Arduino which means choosing boards [supported by the Arduino platform](https://docs.platformio.org/en/latest/frameworks/arduino.html#boards) is easier.
+
+You can comment/uncomment, one of the lines under `platformio` in the configuration file to target just one which is easier/faster for local use. Otherwise the commands you need are
+
+|Name/Action|Command Format|Example|
+|--|--|--|
+|Build (default environments)||`pio run`|
+|Build (specific environment)|`pio run --environment {env-name}`|`pio run --environment uno_wifi_rev2`|
+|Upload (specific environment)|`pio run --environment {env-name} --target upload`|`pio run --environment uno_wifi_rev2 --target upload`|
+|Test||`pio test --environment native`|
+|Clean (default environments)n||`pio run --target fullclean`|
+|Clean (specific environment)|`pio run --environment {env-name} --target fullclean`|`pio run --environment leonardo --target fullclean`|
 
 ## Sensors
 

--- a/mqtt-io.yml
+++ b/mqtt-io.yml
@@ -1,0 +1,96 @@
+logging:
+  version: 1
+  loggers:
+    mqtt_io:
+      level: 'WARN'
+      handlers: ['console']
+      propagate: True
+  handlers:
+    console:
+      class: 'logging.StreamHandler'
+      formatter: 'default'
+      level: 'INFO'
+  formatters:
+    default:
+      format: '%(asctime)s %(name)s [%(levelname)s] %(message)s'
+      datefmt': '%Y-%m-%d %H:%M:%S'
+
+
+mqtt:
+  host: localhost
+  port: 1883
+  user: hamqtt
+  password: "<your-password>" # replace with own password
+  topic_prefix: sensors
+  ha_discovery:
+    enabled: yes
+
+stream_modules:
+  - name: rpiarduino
+    module: serial
+    device: /dev/ttyACM0
+    baud: 9600
+    read_interval: 5
+
+#sensor_modules:
+#  - name: pina0
+#    module: dfr0566_analog
+#    i2c_bus_num: 1
+#    chip_addr: 0x10
+#
+#  - name: dfr_ens160
+#    module: dfr_ens160
+#    i2c_bus_num: 1
+#    chip_addr: 0x53
+#
+#  - name: aht20
+#    module: aht20
+#
+#  - name: yfs201
+#    module: yfs201
+#    pin: 0
+#
+#sensor_inputs:
+#  - name: temperature1
+#    module: aht20
+#    type: temperature
+#    interval: 10
+#
+#  - name: humidity1
+#    module: aht20
+#    type: humidity
+#    interval: 10
+#
+#  - name: light1
+#    module: pina0
+#    pin: 0
+#    digits: 0
+#    interval: 10
+#
+#  - name: flow1
+#    module: yfs201
+#    interval: 10
+#
+#  - name: moisture1
+#    module: pina0
+#    pin: 1
+#    digits: 0
+#    interval: 10
+#
+#  - name: air_quality
+#    module: dfr_ens160
+#    type: aqi
+#    digits: 0
+#    interval: 10
+#
+#  - name: volatile_organic_compounds
+#    module: dfr_ens160
+#    digits: 0
+#    type: tvoc
+#    interval: 10
+#
+#  - name: co2
+#    module: dfr_ens160
+#    digits: 0
+#    type: co2
+#    interval: 10

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,12 +8,8 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:uno_wifi_rev2]
-platform = atmelmegaavr
-board = uno_wifi_rev2
-framework = arduino
+[common]
 lib_deps = 
-	arduino-libraries/WiFiNINA @ ^1.8.13
 	beegee-tokyo/DHT sensor library for ESPx @ ^1.18
 	paulstoffregen/OneWire @ ^2.3.5
 	https://github.com/linucks/DFRobot_EC.git
@@ -32,6 +28,30 @@ build_flags =
 	-DCALIBRATION_TOGGLE_PIN=12
 	-DUSE_INFLUXDB=0
 	-DUSE_HOME_ASSISTANT=1
+
+; The environments specified in default_envs are used when the current command does not have
+; a command override using --environment/-e options
+; Comment/uncomment, one of the lines to target just one which is easier/faster for local use.
+[platformio]
+; default_envs = uno_wifi_rev2
+; default_envs = leonardo
+default_envs = uno_wifi_rev2, leonardo
+
+[env:uno_wifi_rev2]
+platform = atmelmegaavr
+board = uno_wifi_rev2
+framework = arduino
+lib_deps = 
+	${common.lib_deps}
+	arduino-libraries/WiFiNINA @ ^1.8.13
+build_flags = ${common.build_flags}
+
+[env:leonardo]
+platform = atmelavr
+board = leonardo
+framework = arduino
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
 
 ; To be restored once we actually create tests
 ; [env:native]

--- a/src/config.h
+++ b/src/config.h
@@ -51,8 +51,17 @@
   // In case, that does not work, try the other another language via:
   // https://www.arduino.cc/reference/cs/language/functions/external-interrupts/attachinterrupt/
 
-  #ifdef ARDUINO_AVR_UNO_WIFI_REV2
+  #if defined(ARDUINO_AVR_UNO_WIFI_REV2) // all digital pins
     #if SENSORS_SEN0217_PIN < 0 || SENSORS_SEN0217_PIN > 13
+      #error "Pin configured for SEN0217 (flow sensor) must support interrupts."
+    #endif
+  #elif defined(ARDUINO_AVR_LEONARDO) // only 0, 1, 2, 3, 7
+    #if SENSORS_SEN0217_PIN == 0
+    #elif SENSORS_SEN0217_PIN == 1
+    #elif SENSORS_SEN0217_PIN == 2
+    #elif SENSORS_SEN0217_PIN == 3
+    #elif SENSORS_SEN0217_PIN == 7
+    #else
       #error "Pin configured for SEN0217 (flow sensor) must support interrupts."
     #endif
   #else // any other board we have not validated
@@ -66,7 +75,7 @@
   // ensure only digital pins configured
   #ifdef ARDUINO
     #if CALIBRATION_TOGGLE_PIN < 0 || CALIBRATION_TOGGLE_PIN > 13
-      #error "Pin configured for calibration toggle must a digital one.")
+      #error "Pin configured for calibration toggle must a digital one."
     #endif
   #else // any other board we have not validated
     #pragma message "⚠️ Unable to validate pin configured for calibration."
@@ -87,11 +96,19 @@
 
 // Validation of the build configuration
 #if !defined(HAVE_TEMP_HUMIDITY) && (USE_INFLUXDB == 1)
-  #error "Temperature and Humidity sensor must be setup when using InfluxDB directly
+  #error "Temperature and Humidity sensor must be setup when using influxdb directly"
 #endif
 
 #if !defined(HAVE_TEMP_WET) && (defined(HAVE_EC) || defined(HAVE_PH))
   #pragma message "⚠️ Without DS18S20 (wet temperature), calibration or EC and PH sensors is done using air temperature which may not be as accurate!"
+#endif
+
+// WiFi
+#if defined(ARDUINO_AVR_UNO_WIFI_REV2)
+  #define HAVE_WIFI 1
+#elif defined(ARDUINO_AVR_LEONARDO)
+  #undef USE_HOME_ASSISTANT
+  #undef USE_INFLUXDB
 #endif
 
 #endif // CONFIG_H

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -10,7 +10,7 @@
 
 #define KVALUEADDR 0x00
 
-FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)() = nullptr)
+FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)())
 {
 }
 
@@ -271,6 +271,10 @@ float FuFarmSensors::readTempWet()
   ds.write(0x44, 1); // start conversion, with parasite power on at the end
 
   byte present = ds.reset();
+  if (!present)
+  {
+    // TODO: decide if we should return invalid
+  }
   ds.select(addr);
   ds.write(0xBE); // Read Scratchpad
 

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+export PATH=/opt/platformio/bin:$PATH
+
+usage="Usage $0 leonardo|uno_wifi_rev2";
+
+if [ $# -ne 1 ]; then
+    echo $usage
+    exit 1;
+fi
+
+if [ $0 = "leonardo" ]
+then
+    board=leonardo
+elif [ $0 = "uno_wifi_rev2" ]
+then
+    board=uno_wifi_rev2
+else
+    echo $usage
+    exit 1;
+fi
+
+if [ -c /dev/ttyACM0 ]; then
+  atty=/dev/ttyACM0
+elif [ -c /dev/ttyACM1 ]; then
+  atty=/dev/ttyACM1
+else
+  echo Cannot find valid tty file
+  exit 1
+fi
+
+# Command format is pio run --environment {env-name}
+pio run --environment $board
+if [ $? -ne 0 ]; then
+  echo Failed to build!
+  exit 1
+fi
+
+# Command format is pio run --environment {env-name} --target upload --upload-port {port}
+# https://docs.platformio.org/en/latest/projectconf/sections/env/options/upload/upload_port.html
+pio run --environment $board --target upload --upload-port $atty
+if [ $? -ne 0 ]; then
+  echo Failed to upload!
+  exit 1
+fi
+
+echo "Done"


### PR DESCRIPTION
This adds support for Arduino Leonardo in one repository but cleverly using build flags to get things working. Basically, the biggest differences are the pins allowed to interrupt (Leonardo has fewer) and the presence of networking (Leonardo does not but instead prints JSON strings on Serial).

With this we can soon archive the [rpi_shield repository](https://github.com/farm-urban/fufarm_rpi_arduino_shield) because we can compile for multiple boards and target different boards for upload.

Also imported mqtt-io configuration file and upload script though unused in this repository.