### PR TITLE
Remove InfluxDB code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For simplicity doing calibration and to allow you recalibrate on the fly, you ca
 
 ## Data Transmission
 
-The code base supports either sending data to an InfluxDB server or Home Assistant (MQTT). These are controlled by the `USE_INFLUXDB` and `USE_HOME_ASSISTANT` constants which must be set to `1` to enable.
+The code base supports either sending data to Home Assistant (MQTT) or printing out JSON via Serial. To enable HomeAssistant, set `USE_HOME_ASSISTANT` to `1`. HomeAssistant is capable enough to replay the information to any other destination including InfluxDB (which we used to support in this repository).
 
 ## Spelling
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,6 @@ build_flags =
 	-DSENSORS_SEN0217_PIN=3
 	-DSENSORS_DS18S20_PIN=4
 	-DCALIBRATION_TOGGLE_PIN=12
-	-DUSE_INFLUXDB=0
 	-DUSE_HOME_ASSISTANT=1
 
 ; The environments specified in default_envs are used when the current command does not have

--- a/src/config.h
+++ b/src/config.h
@@ -69,6 +69,10 @@
   #endif
 #endif
 
+#ifdef SENSORS_DS18S20_PIN
+  #define HAVE_TEMP_WET
+#endif
+
 #ifdef CALIBRATION_TOGGLE_PIN
   #define SUPPORTS_CALIBRATION
 
@@ -82,25 +86,21 @@
   #endif
 #endif
 
-#ifdef SENSORS_DS18S20_PIN
-  #define HAVE_TEMP_WET
-#endif
-
-#ifndef USE_INFLUXDB
-  #define USE_INFLUXDB 0
-#endif
-
 #ifndef USE_HOME_ASSISTANT
   #define USE_HOME_ASSISTANT 0
 #endif
 
 // Validation of the build configuration
-#if !defined(HAVE_TEMP_HUMIDITY) && (USE_INFLUXDB == 1)
-  #error "Temperature and Humidity sensor must be setup when using influxdb directly"
+#if !defined(HAVE_TEMP_WET) && (defined(HAVE_EC) || defined(HAVE_PH))
+  #pragma message "⚠️ Without DS18S20 (wet temperature), calibration of EC and PH sensors is done using air temperature which may not be as accurate!"
 #endif
 
-#if !defined(HAVE_TEMP_WET) && (defined(HAVE_EC) || defined(HAVE_PH))
-  #pragma message "⚠️ Without DS18S20 (wet temperature), calibration or EC and PH sensors is done using air temperature which may not be as accurate!"
+#if !defined(HAVE_LIGHT) && !defined(HAVE_CO2) && \
+    !defined(HAVE_EC) && !defined(HAVE_PH) && \
+    !defined(HAVE_MOUSTIRE) && !defined(HAVE_TEMP_HUMIDITY) && \
+    !defined(HAVE_FLOW) && !defined(HAVE_TEMP_WET) &&\
+    !defined(MOCK)
+  #error "At least one sensor must be configured unless mocking"
 #endif
 
 // WiFi
@@ -108,7 +108,6 @@
   #define HAVE_WIFI 1
 #elif defined(ARDUINO_AVR_LEONARDO)
   #undef USE_HOME_ASSISTANT
-  #undef USE_INFLUXDB
 #endif
 
 #endif // CONFIG_H

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -20,7 +20,9 @@ FuFarmSensors::~FuFarmSensors()
 
 void FuFarmSensors::begin()
 {
+#ifdef HAVE_TEMP_HUMIDITY
   dht.setup(SENSORS_DHT22_PIN, DHTesp::DHT22);
+#endif
 
 #ifdef HAVE_FLOW
   pulseCount = 0;
@@ -57,7 +59,7 @@ void FuFarmSensors::calibration(unsigned long readIntervalMs)
 #ifdef HAVE_PH
   static float voltagePH, phValue;
 #endif
-  if (millis() - timepoint > readIntervalMs)
+  if ((millis() - timepoint) > readIntervalMs)
   {
     timepoint = millis();
 #ifndef HAVE_TEMP_WET
@@ -132,9 +134,15 @@ void FuFarmSensors::read(FuFarmSensorsData *dest)
 {
   dest->light = readLight();
 
+  float airTemperature = -1;
+#ifdef HAVE_TEMP_HUMIDITY
   TempAndHumidity th = dht.getTempAndHumidity();
-  float airTemperature = dest->temperature.air = th.temperature;
+  airTemperature = dest->temperature.air = th.temperature;
   dest->humidity = th.humidity;
+#else
+  airTemperature = dest->temperature.air = -1;
+  dest->humidity = -1;
+#endif
 
   dest->flow = readFlow();
   dest->co2 = readCO2();

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -1,3 +1,6 @@
+#ifndef SENSORS_H
+#define SENSORS_H
+
 #include <DFRobot_EC.h>
 #include <DFRobot_PH.h>
 #include <DHTesp.h>
@@ -65,3 +68,5 @@ private:
   uint8_t bufferIndex;
   bool cmdSerialDataAvailable();
 };
+
+#endif // SENSORS_H


### PR DESCRIPTION
When using HomeAssistant, you can have the information relayed to InfluxDB. This simplifies our code to a large extent. DHT22 (air temperature and humidity) is not longer mandatory but there must be at least once sensor configured unless mocking.

Following to https://github.com/farm-urban/fufarm_arduino_sensors/issues/9#issuecomment-2730934997