### PR TITLE
Update error messages and include based on config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 Code for Arduino Sensors
 
-This code is built for the [Arduino UNO Wifi R2](https://store.arduino.cc/products/arduino-uno-wifi-rev2) and the [Arduino Leonardo](https://store.arduino.cc/products/arduino-leonardo-with-headers). Other boards might be added with time, if need be. However, should you need to test on another board, [supported by PlatformIO](https://docs.platformio.org/en/latest/boards/index.html), the easiest way would be to add a new environment in the [platformio.ini](./platformio.ini) file. The current code base is built to work with Arduino which means choosing boards [supported by the Arduino platform](https://docs.platformio.org/en/latest/frameworks/arduino.html#boards) is easier.
+This code is built for the following boards:
+
+- [Arduino Leonardo](https://store.arduino.cc/products/arduino-leonardo-with-headers)
+- [Arduino UNO Wifi R2](https://store.arduino.cc/products/arduino-uno-wifi-rev2)
+
+Other boards might be added with time, if need be. However, should you need to test on another board, [supported by PlatformIO](https://docs.platformio.org/en/latest/boards/index.html), the easiest way would be to add a new environment in the [platformio.ini](./platformio.ini) file. The current code base is built to work with Arduino which means choosing boards [supported by the Arduino platform](https://docs.platformio.org/en/latest/frameworks/arduino.html#boards) is easier.
 
 You can comment/uncomment, one of the lines under `platformio` in the configuration file to target just one which is easier/faster for local use. Otherwise the commands you need are
 
@@ -19,17 +24,18 @@ You can comment/uncomment, one of the lines under `platformio` in the configurat
 
 There are a number of sensors used in the farm for different purposes.
 
-| Sensor   | Purpose                        | Pin | Flag                 | Macro         |
-| -------- | ------------------------------ | --- | -------------------- | ------------- |
-| Light    |                                | A0  | SENSORS_LIGHT_PIN    | HAVE_LIGHT    |
-| C02      |                                | A1  | SENSORS_CO2_PIN      | HAVE_CO2      |
-| EC       |                                | A2  | SENSORS_EC_PIN       | HAVE_EC       |
-| pH       |                                | A3  | SENSORS_PH_PIN       | HAVE_PH       |
-| Moisture |                                | A4  | SENSORS_MOISTURE_PIN | HAVE_MOISTURE |
-| AHT20    | Humidity and Temperature (Air) | I2C | HAVE_AHT20           | HAVE_AHT20    |
-| DHT22    | Humidity and Temperature (Air) | 2   | SENSORS_DHT22_PIN    | HAVE_DHT22    |
-| SEN0217  | Flow Sensor                    | 3   | SENSORS_SEN0217_PIN  | HAVE_FLOW     |
-| DS18S20  | Temperature (Wet)              | 4   | SENSORS_DS18S20_PIN  | HAVE_TEMP_WET |
+| Sensor   | Purpose                        | Pin | Flag                 | Macro                  |
+| -------- | ------------------------------ | --- | -------------------- | ---------------------- |
+| Light    |                                | A0  | SENSORS_LIGHT_PIN    | HAVE_LIGHT             |
+| C02      |                                | A1  | SENSORS_CO2_PIN      | HAVE_CO2               |
+| EC       |                                | A2  | SENSORS_EC_PIN       | HAVE_EC                |
+| pH       |                                | A3  | SENSORS_PH_PIN       | HAVE_PH                |
+| Moisture |                                | A4  | SENSORS_MOISTURE_PIN | HAVE_MOISTURE          |
+| AHT20    | Humidity and Temperature (Air) | I2C | HAVE_AHT20           | HAVE_AHT20             |
+| DHT22    | Humidity and Temperature (Air) | 2   | SENSORS_DHT22_PIN    | HAVE_DHT22             |
+| SEN0217  | Flow Sensor                    | 3   | SENSORS_SEN0217_PIN  | HAVE_FLOW              |
+| DS18S20  | Temperature (Wet)              | 4   | SENSORS_DS18S20_PIN  | HAVE_TEMP_WET          |
+| SEN0204  | Water Level Sensor             | 5   | SENSORS_SEN0204_PIN  | HAVE_WATER_LEVEL_STATE |
 
 When you start using this, you might not have/need all of these. You can remove the ones you do not have/need by editing `build_flags` in [platformio.ini](./platformio.ini). For example, if you do not have pH sensor, you can remove the line containing `-DSENSORS_PH_PIN=A3`. By default, when a sensor is not enabled, the value is `-1` to signify invalid.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,9 +35,9 @@ build_flags =
 ; a command override using --environment/-e options
 ; Comment/uncomment, one of the lines to target just one which is easier/faster for local use.
 [platformio]
-; default_envs = uno_wifi_rev2
 ; default_envs = leonardo
-default_envs = uno_wifi_rev2, leonardo
+; default_envs = uno_wifi_rev2
+; default_envs = leonardo, uno_wifi_rev2
 
 [env:uno_wifi_rev2]
 platform = atmelmegaavr

--- a/src/config.h
+++ b/src/config.h
@@ -32,28 +32,17 @@
 
 #ifdef SENSORS_DHT22_PIN
   #define HAVE_DHT22
-
-  // ensure only digital pins configured
-  #ifdef ARDUINO
-    #if SENSORS_DHT22_PIN < 0 || SENSORS_DHT22_PIN > 13
-      #error "Pin configured for DHT22 must a digital one."
-    #endif
-  #else // any other board we have not validated
-    #pragma message "⚠️ Unable to validate pin configured for DHT22."
-  #endif
 #endif
 
 #ifdef SENSORS_SEN0217_PIN
   #define HAVE_FLOW
 
   // For this flow sensor, only interrupt pins should be used. Configured on a rising edge
-  // https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/
-  // In case, that does not work, try the other another language via:
-  // https://www.arduino.cc/reference/cs/language/functions/external-interrupts/attachinterrupt/
+  // https://reference.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/
 
   #if defined(ARDUINO_AVR_UNO_WIFI_REV2) // all digital pins
     #if SENSORS_SEN0217_PIN < 0 || SENSORS_SEN0217_PIN > 13
-      #error "Pin configured for SEN0217 (flow sensor) must support interrupts."
+      #error "Pin configured for SEN0217 (flow sensor) must support interrupts on UNO WIFI REV2."
     #endif
   #elif defined(ARDUINO_AVR_LEONARDO) // only 0, 1, 2, 3, 7
     #if SENSORS_SEN0217_PIN == 0
@@ -62,7 +51,7 @@
     #elif SENSORS_SEN0217_PIN == 3
     #elif SENSORS_SEN0217_PIN == 7
     #else
-      #error "Pin configured for SEN0217 (flow sensor) must support interrupts."
+      #error "Pin configured for SEN0217 (flow sensor) must support interrupts on LEONARDO."
     #endif
   #else // any other board we have not validated
     #pragma message "⚠️ Unable to validate if pin configured for SEN0217 (flow sensor) allows interrupts required."
@@ -79,15 +68,6 @@
 
 #ifdef CALIBRATION_TOGGLE_PIN
   #define SUPPORTS_CALIBRATION
-
-  // ensure only digital pins configured
-  #ifdef ARDUINO
-    #if CALIBRATION_TOGGLE_PIN < 0 || CALIBRATION_TOGGLE_PIN > 13
-      #error "Pin configured for calibration toggle must a digital one."
-    #endif
-  #else // any other board we have not validated
-    #pragma message "⚠️ Unable to validate pin configured for calibration."
-  #endif
 #endif
 
 #ifndef USE_HOME_ASSISTANT
@@ -106,9 +86,9 @@
 #if !defined(HAVE_LIGHT) && !defined(HAVE_CO2) && \
     !defined(HAVE_EC) && !defined(HAVE_PH) && \
     !defined(HAVE_MOISTURE) && !defined(HAVE_DHT22) && \
-    !defined(HAVE_FLOW) && !defined(HAVE_TEMP_WET) &&\
-    !defined(HAVE_WATER_LEVEL_STATE) && !defined(HAVE_AHT20) &&\
-    !defined(MOCK) 
+    !defined(HAVE_FLOW) && !defined(HAVE_TEMP_WET) && \
+    !defined(HAVE_WATER_LEVEL_STATE) && !defined(HAVE_AHT20) && \
+    !defined(MOCK)
   #error "At least one sensor must be configured unless mocking"
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 
+#if HAVE_WIFI
 /*
  * Need to update the firmware on the Wifi Uno Rev2 and upload the SSL certificate for INFLUXDB_SERVER
  * Getting this to work required multiple attempts and deleting the arduino.cc certificate. Instructions
@@ -7,7 +8,6 @@
  *
  * */
 #include <SPI.h>
-#if HAVE_WIFI
 // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-reason-code
 #include <WiFiNINA.h>
 #endif

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -2,10 +2,23 @@
 #define SENSORS_H
 
 #include "config.h"
+
+#ifdef HAVE_EC
 #include <DFRobot_EC.h>
+#endif
+
+#ifdef HAVE_PH
 #include <DFRobot_PH.h>
+#endif
+
+#ifdef HAVE_DHT22
 #include <DHTesp.h>
+#endif
+
+#ifdef HAVE_TEMP_WET
 #include <OneWire.h>
+#endif
+
 #ifdef HAVE_AHT20
 #include <DFRobot_AHT20.h>
 #endif


### PR DESCRIPTION
- Updated the error messages for interrupt to be more specific.
- No need to validate whether pin is digital pin as any pin can be used.
- Only include (aka import) libraries for sensors when configured. Already existed for AHT20.
- Add missing SEN0204 to the list of sensors.