### PR TITLE
Support 802.1x WiFi and public networks

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,14 @@ build_flags =
 	-DHAVE_AHT20=1
 	-DCALIBRATION_TOGGLE_PIN=12
 	-DUSE_HOME_ASSISTANT=1
+build_flags_wifi = 
+	-DWIFI_SSID=\"fumanc\"
+	; -DWIFI_PASSPHRASE=\"<your-value>\"
+	; in most cases you do not need enterprise wifi but if you do, maybe just the username and password
+	; -DWIFI_ENTERPRISE_USERNAME=\"johnson@gov.uk\"
+	; -DWIFI_ENTERPRISE_PASSWORD=\"<your-value>\"
+	; -DWIFI_ENTERPRISE_IDENTITY=\"<your-value>\"
+	; -DWIFI_ENTERPRISE_CA=\"<your-value>\"
 
 ; The environments specified in default_envs are used when the current command does not have
 ; a command override using --environment/-e options
@@ -46,7 +54,9 @@ framework = arduino
 lib_deps = 
 	${common.lib_deps}
 	arduino-libraries/WiFiNINA@^1.8.13
-build_flags = ${common.build_flags}
+build_flags = 
+	${common.build_flags}
+	${common.build_flags_wifi}
 
 [env:leonardo]
 platform = atmelavr

--- a/src/config.h
+++ b/src/config.h
@@ -99,4 +99,16 @@
   #undef USE_HOME_ASSISTANT
 #endif
 
+#if (defined(WIFI_ENTERPRISE_USERNAME) && !defined(WIFI_ENTERPRISE_PASSWORD)) || \
+    (!defined(WIFI_ENTERPRISE_USERNAME) && defined(WIFI_ENTERPRISE_PASSWORD))
+  #error "Enterprise WIFI (802.1x) requires both username and password"
+#else
+  #ifndef WIFI_ENTERPRISE_IDENTITY
+    #define WIFI_ENTERPRISE_IDENTITY "" // default in the library
+  #endif
+  #ifndef WIFI_ENTERPRISE_CA
+    #define WIFI_ENTERPRISE_CA "" // default in the library
+  #endif
+#endif
+
 #endif // CONFIG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,10 +39,6 @@ static boolean calibrationMode = false;
 
 // Wifi control
 #if HAVE_WIFI
-char ssid[] = "fumanc";
-char pass[] = "FARM123!";
-// char ssid[] = "PLUSNET-CFC9WG";
-// char pass[] = "G7UtKycGmxGYDq";
 int wifiStatus = WL_IDLE_STATUS; // the Wifi radio's status
 WiFiClient wifiClient;
 #else
@@ -175,9 +171,19 @@ void connectToWifi()
       Serial.println();
     }
     Serial.print("Attempting to connect to WPA SSID: ");
-    Serial.println(ssid);
+    Serial.println(WIFI_SSID);
     WiFi.disconnect(); // Clear network stack https://forum.arduino.cc/t/mqtt-with-esp32-gives-timeout-exceeded-disconnecting/688723/5
-    wifiStatus = WiFi.begin(ssid, pass);
+#if defined(WIFI_ENTERPRISE_USERNAME) && defined(WIFI_ENTERPRISE_PASSWORD)
+    wifiStatus = WiFi.beginEnterprise(WIFI_SSID,
+                                      WIFI_ENTERPRISE_USERNAME,
+                                      WIFI_ENTERPRISE_PASSWORD,
+                                      WIFI_ENTERPRISE_IDENTITY,
+                                      WIFI_ENTERPRISE_CA);
+#elif defined(WIFI_PASSPHRASE)
+    wifiStatus = WiFi.begin(WIFI_SSID, WIFI_PASSPHRASE);
+#else
+    wifiStatus = WiFi.begin(WIFI_SSID);
+#endif
     delay(10000);
     attempts++;
   }


### PR DESCRIPTION
802.1x networks need a username, password and optionally an identity and CA. Whereas this is commonly referred to as Enterprise WiFi, it is commonly used in shared spaces. It is configured optional and off by default.
Consequently, WiFi configuration is moved to flags just like the sensors.
Also, public WiFi can be used (just an SSID and no passphrase)

Reading (if needed): https://www.securew2.com/solutions/802-1x