### PR TITLE
Use the official DFRobot libraries for EC and PH

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,10 +12,10 @@
 lib_deps = 
 	beegee-tokyo/DHT sensor library for ESPx@^1.18
 	paulstoffregen/OneWire@^2.3.5
-	https://github.com/linucks/DFRobot_EC.git#61bfaae
-	https://github.com/linucks/DFRobot_PH.git#25234d7
+	https://github.com/DFRobot/DFRobot_AHT20.git
+	https://github.com/DFRobot/DFRobot_EC.git
+	https://github.com/DFRobot/DFRobot_PH.git
 	knolleary/PubSubClient@^2.8
-	dfrobot/DFRobot_AHT20@^1.0.0
 	bblanchon/ArduinoJson@^6.21.3
 build_flags = 
 	-DSENSORS_LIGHT_PIN=A0

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -159,10 +159,13 @@ void FuFarmSensors::read(FuFarmSensorsData *dest)
   airTemperature = dest->temperature.air = th.temperature;
   dest->humidity = th.humidity;
 #elif HAVE_AHT20
-  if(aht20.startMeasurementReady(true)){
+  if (aht20.startMeasurementReady(true))
+  {
     airTemperature = dest->temperature.air = aht20.getTemperature_C();
     dest->humidity = aht20.getHumidity_RH();
-  } else {
+  }
+  else
+  {
     Serial.println("AHT20 sensor not ready");
     airTemperature = dest->temperature.air = -1;
     dest->humidity = -1;
@@ -206,7 +209,6 @@ bool FuFarmSensors::readWaterLevelState()
   return false;
 #endif
 }
-
 
 int FuFarmSensors::readLight()
 {
@@ -366,4 +368,17 @@ bool FuFarmSensors::cmdSerialDataAvailable()
     }
   }
   return false;
+}
+
+char *FuFarmSensors::strupr(char *str)
+{
+  if (str == NULL)
+    return NULL;
+  char *ptr = str;
+  while (*ptr != ' ')
+  {
+    *ptr = toupper((unsigned char)*ptr);
+    ptr++;
+  }
+  return str;
 }

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -25,12 +25,14 @@
 
 #include "config.h"
 
-struct FuFarmSensorsData {
+struct FuFarmSensorsData
+{
   int light;
   float humidity;
   float flow;
   int co2;
-  struct FuFarmSensorsTemperature {
+  struct FuFarmSensorsTemperature
+  {
     float air;
     float wet;
   } temperature;
@@ -47,7 +49,7 @@ public:
   ~FuFarmSensors();
   void begin();                                           // initialization
   void calibration(unsigned long readIntervalMs = 1000U); // calibration, should be called in a loop, ideally a config mode
-  void read(FuFarmSensorsData* dest);                     // read all sensor data
+  void read(FuFarmSensorsData *dest);                     // read all sensor data
   void sen0217Interrupt();                                // should be called from the interrupt handler passed in the constructor
 
 private:
@@ -88,6 +90,7 @@ private:
   char buffer[10];
   uint8_t bufferIndex;
   bool cmdSerialDataAvailable();
+  char *strupr(char *str);
 };
 
 #endif // SENSORS_H


### PR DESCRIPTION
Fixes #15 

The `strupr(...)` function is now local to allow for non-AVR boards (e.g. Uno R4 WiFi).