### PR TITLE
Move Home Assistant configuration to flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For simplicity doing calibration and to allow you recalibrate on the fly, you ca
 
 ## Data Transmission
 
-The code base supports either sending data to Home Assistant (MQTT) or printing out JSON via Serial. To enable HomeAssistant, set `USE_HOME_ASSISTANT` to `1`. HomeAssistant is capable enough to replay the information to any other destination including InfluxDB (which we used to support in this repository).
+The code base supports either sending data to Home Assistant (MQTT) or printing out JSON via Serial. Data is sent to HomeAssistant, if the board has network support (e.g. WiFi). HomeAssistant is capable enough to replay the information to any other destination including InfluxDB (which we used to support in this repository).
 
 ## Spelling
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,11 @@ build_flags =
 	-DSENSORS_SEN0204_PIN=5
 	-DHAVE_AHT20=1
 	-DCALIBRATION_TOGGLE_PIN=12
-	-DUSE_HOME_ASSISTANT=1
+	-DHOME_ASSISTANT_MQTT_CLIENT_ID=\"ard1\"
+	-DHOME_ASSISTANT_MQTT_SERVER_IP=\"192.168.8.100\"
+	-DHOME_ASSISTANT_MQTT_SERVER_PORT=1883
+	-DHOME_ASSISTANT_MQTT_USER=\"ard1\"
+	-DHOME_ASSISTANT_MQTT_PASSWORD=\"0\"
 build_flags_wifi = 
 	-DWIFI_SSID=\"fumanc\"
 	; -DWIFI_PASSPHRASE=\"<your-value>\"
@@ -45,25 +49,25 @@ build_flags_wifi =
 [platformio]
 ; default_envs = leonardo
 ; default_envs = uno_wifi_rev2
-; default_envs = leonardo, uno_wifi_rev2
+default_envs = leonardo, uno_wifi_rev2
+
+[env:leonardo]
+platform = atmelavr
+framework = arduino
+board = leonardo
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
 
 [env:uno_wifi_rev2]
 platform = atmelmegaavr
-board = uno_wifi_rev2
 framework = arduino
+board = uno_wifi_rev2
 lib_deps = 
 	${common.lib_deps}
 	arduino-libraries/WiFiNINA@^1.8.13
 build_flags = 
 	${common.build_flags}
 	${common.build_flags_wifi}
-
-[env:leonardo]
-platform = atmelavr
-board = leonardo
-framework = arduino
-lib_deps = ${common.lib_deps}
-build_flags = ${common.build_flags}
 
 ; To be restored once we actually create tests
 ; [env:native]

--- a/src/config.h
+++ b/src/config.h
@@ -70,10 +70,6 @@
   #define SUPPORTS_CALIBRATION
 #endif
 
-#ifndef USE_HOME_ASSISTANT
-  #define USE_HOME_ASSISTANT 0
-#endif
-
 // Validation of the build configuration
 #if !defined(HAVE_TEMP_WET) && (defined(HAVE_EC) || defined(HAVE_PH))
   #pragma message "⚠️ Without DS18S20 (wet temperature), calibration of EC and PH sensors is done using air temperature which may not be as accurate!"
@@ -96,7 +92,7 @@
 #if defined(ARDUINO_AVR_UNO_WIFI_REV2)
   #define HAVE_WIFI 1
 #elif defined(ARDUINO_AVR_LEONARDO)
-  #undef USE_HOME_ASSISTANT
+  #define HAVE_WIFI 0
 #endif
 
 #if (defined(WIFI_ENTERPRISE_USERNAME) && !defined(WIFI_ENTERPRISE_PASSWORD)) || \
@@ -109,6 +105,11 @@
   #ifndef WIFI_ENTERPRISE_CA
     #define WIFI_ENTERPRISE_CA "" // default in the library
   #endif
+#endif
+
+// MQTT
+#ifndef HOME_ASSISTANT_MQTT_KEEPALIVE
+  #define HOME_ASSISTANT_MQTT_KEEPALIVE 90
 #endif
 
 #endif // CONFIG_H


### PR DESCRIPTION
Moving the configuration for Home Assistant to PIO configuration file.

Also replaces `USE_HOME_ASSISTANT` with `HAVE_WIFI` because when there is network, that's all that