### PR TITLE
Fixing versions for dependencies and fix permissions for PRs

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 2 2 * *' # Runs at 01:00 on the second day of the month
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   Updates:
     runs-on: ubuntu-latest

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,13 +10,13 @@
 
 [common]
 lib_deps = 
-	beegee-tokyo/DHT sensor library for ESPx@^1.18
-	paulstoffregen/OneWire@^2.3.5
+	beegee-tokyo/DHT sensor library for ESPx@1.18
+	paulstoffregen/OneWire@2.3.5
 	https://github.com/DFRobot/DFRobot_AHT20.git
 	https://github.com/DFRobot/DFRobot_EC.git
 	https://github.com/DFRobot/DFRobot_PH.git
-	knolleary/PubSubClient@^2.8
-	bblanchon/ArduinoJson@^6.21.3
+	knolleary/PubSubClient@2.8
+	bblanchon/ArduinoJson@6.21.3
 build_flags = 
 	-DSENSORS_LIGHT_PIN=A0
 	-DSENSORS_CO2_PIN=A1
@@ -66,7 +66,7 @@ framework = arduino
 board = uno_wifi_rev2
 lib_deps = 
 	${common.lib_deps}
-	arduino-libraries/WiFiNINA@^1.8.13
+	arduino-libraries/WiFiNINA@1.8.13
 build_flags = 
 	${common.build_flags}
 	${common.build_flags_wifi}


### PR DESCRIPTION
While SemVer is a well accepted way of doing versioning of components, sometimes breaking changes are not as breaking to everyone. It may be better to fix versions of the dependencies we use. Also added relevant permissions to the updates workflow to allow it do the needful.