### PR TITLE
Config bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ You can comment/uncomment, one of the lines under `platformio` in the configurat
 | Clean (default environments)n |                                                       | `pio run --target fullclean`                          |
 | Clean (specific environment)  | `pio run --environment {env-name} --target fullclean` | `pio run --environment leonardo --target fullclean`   |
 
+## WiFi
+
+Boards that support WiFi are generally easier to work with because they transmit directly to Home Assistant. The WiFi network you connect to is controlled by the common `build_flags_wifi` in `platformio.ini`.
+
+- To connect to a public network, you only need to configure `-DWIFI_SSID=\"<your-network>\"` for example, `-DWIFI_SSID=\"Airport_Free_WiFi\"
+- To connect to a simple WPA2 network, you need to set both `-DWIFI_SSID=\"<your-network>\"` and `-DWIFI_PASSPHRASE=\"<your-value>\"`
+- To connect to an 802.1x or enterprise network, you need to set `; -DWIFI_PASSPHRASE=\"<your-value>\"`, `-DWIFI_ENTERPRISE_USERNAME=\"<your-value>\"`, and `-DWIFI_ENTERPRISE_PASSWORD=\"<your-value>\"`. Optionally, you may need `-DWIFI_ENTERPRISE_IDENTITY=\"<your-value>\"` or `-DWIFI_ENTERPRISE_CA=\"<your-value>\"`. This is for networks such as those used at hospitals for staff members, universities, shared accommodation or maybe your workplace.
+
+> [!NOTE]
+>
+> 1. Networks with captive portals do not work.
+> 2. Networks with spaces need to be escaped appropriately. For example, to connect to a network named `ASK4 Wireless`, you should use `-DWIFI_SSID=\"ASK4\ Wireless\"`. To connect to a network named `Jen's iPhone`, you should use `-DWIFI_SSID=\"Jen\'s\ iPhone\"`
+> 3. Arduino UNO R4 WiFi, does not (yet) support enterprise WiFi.
+
+### WiFi Firmware
+
+The WiFi modules may need firmware updates to work properly such as when using an older board or you have not used a particular board for a while. In some cases, multiple attempts may be required. See:
+
+- [Arduino UNO R4 WiFi](https://support.arduino.cc/hc/en-us/articles/9670986058780-Update-the-connectivity-module-firmware-on-UNO-R4-WiFi)
+- [Arduino UNO WiFi Rev2](https://github.com/xcape-io/ArduinoProps/blob/master/help/WifiNinaFirmware.md)
+
 ## Sensors
 
 There are a number of sensors used in the farm for different purposes.

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,8 @@ lib_deps =
 	knolleary/PubSubClient@2.8
 	bblanchon/ArduinoJson@6.21.3
 build_flags = 
+	; sample time in milliseconds (60k = 60seconds or 1 minute)
+	-DSAMPLE_WINDOW_MILLIS=60000
 	-DSENSORS_LIGHT_PIN=A0
 	-DSENSORS_CO2_PIN=A1
 	-DSENSORS_EC_PIN=A2

--- a/src/config.h
+++ b/src/config.h
@@ -3,13 +3,6 @@
 
 // #define MOCK ; // Uncomment to skip wifi connection for testing sensors
 
-#ifdef MOCK
-#define SAMPLE_WINDOW 5000
-#else
-// Time in milliseconds - 5 minutes = 1000 * 60 * 5 = 300000
-#define SAMPLE_WINDOW 60000
-#endif
-
 #ifdef SENSORS_LIGHT_PIN
   #define HAVE_LIGHT
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,11 @@
 
 // #define MOCK ; // Uncomment to skip wifi connection for testing sensors
 
+#ifndef SAMPLE_WINDOW
+// Time in milliseconds - 1 minute = 1000 * 60 * 5 = 300000
+#define SAMPLE_WINDOW 300000
+#endif
+
 #ifdef SENSORS_LIGHT_PIN
   #define HAVE_LIGHT
 #endif
@@ -42,13 +47,13 @@
     #else
       #error "Pin configured for SEN0217 (flow sensor) must support interrupts on LEONARDO."
     #endif
-  #elif defined(ARDUINO_UNOR4_WIFI) // all digital pins
+  #elif defined(ARDUINO_AVR_UNO_WIFI_REV2) // all digital pins
     #if SENSORS_SEN0217_PIN < 0 || SENSORS_SEN0217_PIN > 13
       #error "Pin configured for SEN0217 (flow sensor) must support interrupts on UNO WIFI REV2."
     #endif
-  #elif defined(ARDUINO_AVR_UNO_WIFI_REV2) // only 2 or 3
+  #elif defined(ARDUINO_UNOR4_WIFI) // only 2 or 3
     #if SENSORS_SEN0217_PIN != 2 && SENSORS_SEN0217_PIN != 3
-      #error "Pin configured for SEN0217 (flow sensor) must support interrupts on UNO R4 WIFI."
+      #error "Pin configured for SEN0217 (flow sensor) must support interrupts on UNO WIFI REV2UNO R4 WIFI."
     #endif
   #else // any other board we have not validated
     #pragma message "⚠️ Unable to validate if pin configured for SEN0217 (flow sensor) allows interrupts required."

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,13 +3,6 @@
 #if defined(ARDUINO_UNOR4_WIFI)
 #include <WiFiS3.h>
 #elif defined(ARDUINO_AVR_UNO_WIFI_REV2)
-/*
- * Need to update the firmware on the Wifi Uno Rev2 and upload the SSL certificate for INFLUXDB_SERVER
- * Getting this to work required multiple attempts and deleting the arduino.cc certificate. Instructions
- * are available at: https://github.com/xcape-io/ArduinoProps/blob/master/help/WifiNinaFirmware.md
- *
- * */
-// https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-reason-code
 #include <WiFiNINA.h>
 #endif
 
@@ -377,7 +370,7 @@ void setup()
   sensors.begin();
 
   // if calibration toggle is shorted then we are in calibration mode
-  #ifdef SUPPORTS_CALIBRATION
+#ifdef SUPPORTS_CALIBRATION
   pinMode(CALIBRATION_TOGGLE_PIN, INPUT_PULLUP);
   calibrationMode = digitalRead(CALIBRATION_TOGGLE_PIN) == 0;
   if (calibrationMode) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,7 +201,7 @@ void haAnnounceSensor(String name, String type, bool isBinary, JsonDocument& pay
   payload["state_topic"] = state_topic;
   payload["unique_id"] = sensor_name;
   // payload["unit_of_measurement"] = measurement;
-  payload["expire_after"] = (String)(SAMPLE_WINDOW * 2);
+  payload["expire_after"] = (String)(SAMPLE_WINDOW_MILLIS * 2);
   serializeJson(payload, buffer, BUFFER_SIZE);
   String info = "Announcing sensor: " + config_topic + "\n" + buffer;
   Serial.println(info);
@@ -498,5 +498,5 @@ void loop()
   Serial.println();
   Serial.flush();
 #endif
-  delay(SAMPLE_WINDOW);
+  delay(SAMPLE_WINDOW_MILLIS);
 } // end loop

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -2,12 +2,13 @@
 #include <EEPROM.h>
 #include "sensors.h"
 
-// Will be different depending on the reference voltage
+// Will be different depending on the reference voltage.
+// We use float to avoid integer overflow.
 #ifdef ARDUINO_UNOR4_WIFI
-#define ANALOG_REFERENCE_MILLI_VOLTS 5000
+#define ANALOG_REFERENCE_MILLI_VOLTS 5000.0f
 #define ANALOG_MAX_VALUE 16384 // 14 bit ADC
 #else
-#define ANALOG_REFERENCE_MILLI_VOLTS 5000
+#define ANALOG_REFERENCE_MILLI_VOLTS 5000.0f
 #define ANALOG_MAX_VALUE 1024 // 10 bit ADC
 #endif
 // to avoid possible loss of precision, multiply before dividing

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -315,9 +315,9 @@ float FuFarmSensors::readFlow()
    * From YF-S201 manual:
    * Pulse Characteristic:F=7Q(L/MIN).
    * 2L/MIN=16HZ 4L/MIN=32.5HZ 6L/MIN=49.3HZ 8L/MIN=65.5HZ 10L/MIN=82HZ
-   * sample_window is in milli seconds, so hz is pulseCount * 1000 / SAMPLE_WINDOW
+   * sample_window is in milli seconds, so hz is pulseCount * 1000 / SAMPLE_WINDOW_MILLIS
    * */
-  float hertz = (float)(pulseCount * 1000.0) / SAMPLE_WINDOW;
+  float hertz = (float)(pulseCount * 1000.0) / SAMPLE_WINDOW_MILLIS;
   pulseCount = 0; // reset flow counter
   return hertz / 7.0;
 #else

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -16,7 +16,11 @@
 
 #define KVALUEADDR 0x00
 
+#ifdef HAVE_ENS160
 FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)()) : ens160(&Wire, /* I2C Address */ 0x53)
+#else
+FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)())
+#endif
 {
 }
 
@@ -72,6 +76,7 @@ void FuFarmSensors::begin()
   pulseCount = 0;
   if (sen0217InterruptHandler != nullptr)
   {
+    Serial.println(F("Flow sensor enabled"));
     attachInterrupt(digitalPinToInterrupt(SENSORS_SEN0217_PIN), sen0217InterruptHandler, RISING);
   }
 #endif


### PR DESCRIPTION
This is a first attempt a fixing a build without the ENS160 sensor present.

It also makes SAMPLE_WINDOW a build time parameter, uncoupled from MOCK so it's easier and clearer to change.

There is also a bug here, where if the flow sensor is defined (i.e. -DSENSORS_SEN0217_PIN is defined), sen0217InterruptHandler in sensors.cpp (line 76) is never not a nullptr, so the flow rate is no longer measured.

@mburumaxwell I'm a bit confused about the logic of defining the sen0217InterruptHandler so could you take a look as part of your review?