### PR TITLE
Convert to float when reading ADC to avoid int overflow

### DIFF
--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -2,12 +2,13 @@
 #include <EEPROM.h>
 #include "sensors.h"
 
-// Will be different depending on the reference voltage
+// Will be different depending on the reference voltage.
+// We use float to avoid integer overflow.
 #ifdef ARDUINO_UNOR4_WIFI
-#define ANALOG_REFERENCE_MILLI_VOLTS 5000
+#define ANALOG_REFERENCE_MILLI_VOLTS 5000.0f
 #define ANALOG_MAX_VALUE 16384 // 14 bit ADC
 #else
-#define ANALOG_REFERENCE_MILLI_VOLTS 5000
+#define ANALOG_REFERENCE_MILLI_VOLTS 5000.0f
 #define ANALOG_MAX_VALUE 1024 // 10 bit ADC
 #endif
 // to avoid possible loss of precision, multiply before dividing


### PR DESCRIPTION
When reading the values from ADC, we convert them to millivolts which means multiplication by at least 1,000 and division by a number based on the precision of the ADC peripheral/block. To avoid loosing data/precision, we do multiplication first then the division later. However, when the original value is a 16 bit number, we hit an overflow and this results in negative numbers. To fix this, we convert to float during the first operation. We could also convert to `uint32_t` but `float` is more common in the setup we have and they both use  4 bytes.