### PR TITLE
Configure sampling duration using flags for centrality

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,8 @@ lib_deps =
 	knolleary/PubSubClient@2.8
 	bblanchon/ArduinoJson@6.21.3
 build_flags = 
+	; sample time in milliseconds (60k = 60seconds or 1 minute)
+	-DSAMPLE_WINDOW_MILLIS=60000
 	-DSENSORS_LIGHT_PIN=A0
 	-DSENSORS_CO2_PIN=A1
 	-DSENSORS_EC_PIN=A2

--- a/src/config.h
+++ b/src/config.h
@@ -3,13 +3,6 @@
 
 // #define MOCK ; // Uncomment to skip wifi connection for testing sensors
 
-#ifdef MOCK
-#define SAMPLE_WINDOW 5000
-#else
-// Time in milliseconds - 5 minutes = 1000 * 60 * 5 = 300000
-#define SAMPLE_WINDOW 60000
-#endif
-
 #ifdef SENSORS_LIGHT_PIN
   #define HAVE_LIGHT
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,7 +208,7 @@ void haAnnounceSensor(String name, String type, bool isBinary, JsonDocument& pay
   payload["state_topic"] = state_topic;
   payload["unique_id"] = sensor_name;
   // payload["unit_of_measurement"] = measurement;
-  payload["expire_after"] = (String)(SAMPLE_WINDOW * 2);
+  payload["expire_after"] = (String)(SAMPLE_WINDOW_MILLIS * 2);
   serializeJson(payload, buffer, BUFFER_SIZE);
   String info = "Announcing sensor: " + config_topic + "\n" + buffer;
   Serial.println(info);
@@ -505,5 +505,5 @@ void loop()
   Serial.println();
   Serial.flush();
 #endif
-  delay(SAMPLE_WINDOW);
+  delay(SAMPLE_WINDOW_MILLIS);
 } // end loop

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -315,9 +315,9 @@ float FuFarmSensors::readFlow()
    * From YF-S201 manual:
    * Pulse Characteristic:F=7Q(L/MIN).
    * 2L/MIN=16HZ 4L/MIN=32.5HZ 6L/MIN=49.3HZ 8L/MIN=65.5HZ 10L/MIN=82HZ
-   * sample_window is in milli seconds, so hz is pulseCount * 1000 / SAMPLE_WINDOW
+   * sample_window is in milli seconds, so hz is pulseCount * 1000 / SAMPLE_WINDOW_MILLIS
    * */
-  float hertz = (float)(pulseCount * 1000.0) / SAMPLE_WINDOW;
+  float hertz = (float)(pulseCount * 1000.0) / SAMPLE_WINDOW_MILLIS;
   pulseCount = 0; // reset flow counter
   return hertz / 7.0;
 #else


### PR DESCRIPTION
Similar to the other configurations, sampling window is now setup in `platformio.ini`. Renamed it from `SAMPLE_WINDOW` to `SAMPLE_WINDOW_MILLIS` to be more specific on the expected value.