### PR TITLE
Fix constructor for `FuFarmSensors`

### DIFF
--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -16,8 +16,13 @@
 
 #define KVALUEADDR 0x00
 
+#ifdef HAVE_ENS160
 FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)()) : ens160(&Wire, /* I2C Address */ 0x53)
+#else
+FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)())
+#endif
 {
+  this->sen0217InterruptHandler = sen0217InterruptHandler;
 }
 
 FuFarmSensors::~FuFarmSensors()


### PR DESCRIPTION
The constructor for `ENS160` should only be called if it is enabled. Also assigned `sen0217InterruptHandler` which was missing.

@linucks this should help with #22