### PR TITLE
Validation of sensors selection in build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ on:
       - .github/**
       - '!.github/workflows/ci.yml'
 
+env:
+  CI: 1 # Needed for PlatformIO? https://docs.platformio.org/en/stable/envvars.html#envvar-CI
+
 jobs:
   Build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Boards that support WiFi are generally easier to work with because they transmit
 > [!NOTE]
 >
 > 1. Networks with captive portals do not work.
-> 2. Networks with spaces need to be escaped appropriately. For example, to connect to a network named `ASK4 Wireless`, you should use `-DWIFI_SSID=\"ASK4\ Wireless\"`. To connect to a network named `Jen's iPhone`, you should use `-DWIFI_SSID=\"Jen\'s\ iPhone\"`
+> 2. Networks with spaces need to be escaped appropriately. For example, to connect to a network named `ASK4 Wireless`, you should use `-DWIFI_SSID=\"ASK4\ Wireless\"`. To connect to a network named `Jen's iPhone`, you should use `-DWIFI_SSID=\"Jen\'s\ iPhone\"`. At times, the device is unable to connect when there are special characters, renaming your phone should fix it, e.g `Jen's iphone` -> `JensiPhone`.
 > 3. Arduino UNO R4 WiFi, does not (yet) support enterprise WiFi.
 
 ### WiFi Firmware

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ lib_deps =
 build_flags = 
 	; sample time in milliseconds (60k = 60seconds or 1 minute)
 	-DSAMPLE_WINDOW_MILLIS=60000
+build_flags_sensors = 
 	-DSENSORS_LIGHT_PIN=A0
 	-DSENSORS_CO2_PIN=A1
 	-DSENSORS_EC_PIN=A2
@@ -33,6 +34,7 @@ build_flags =
 	-DHAVE_AHT20=1
 	-DHAVE_ENS160=1
 	-DCALIBRATION_TOGGLE_PIN=12
+build_flags_ha = 
 	-DHOME_ASSISTANT_MQTT_SERVER_IP=\"192.168.8.100\"
 	-DHOME_ASSISTANT_MQTT_SERVER_PORT=1883
 	-DHOME_ASSISTANT_MQTT_CLIENT_ID=\"ard1\"
@@ -55,14 +57,29 @@ build_flags_wifi =
 ; default_envs = leonardo
 ; default_envs = uno_r4_wifi
 ; default_envs = uno_wifi_rev2
-default_envs = leonardo, uno_r4_wifi, uno_wifi_rev2
+default_envs = leonardo, uno_r4_wifi, uno_wifi_rev2, ci_validation_1, ci_validation_2
 
 [env:leonardo]
 platform = atmelavr
 framework = arduino
 board = leonardo
 lib_deps = ${common.lib_deps}
-build_flags = ${common.build_flags}
+build_flags = 
+	${common.build_flags}
+	${common.build_flags_sensors}
+
+[env:uno_r4_wifi]
+platform = renesas-ra
+framework = arduino
+board = uno_r4_wifi
+lib_deps = ${common.lib_deps}
+build_flags = 
+	${common.build_flags}
+	${common.build_flags_sensors}
+	${common.build_flags_wifi}
+	${common.build_flags_ha}
+; needed for WiFi sublibraries to be found correctly
+lib_ldf_mode = deep+
 
 [env:uno_wifi_rev2]
 platform = atmelmegaavr
@@ -73,18 +90,19 @@ lib_deps =
 	arduino-libraries/WiFiNINA@1.8.13
 build_flags = 
 	${common.build_flags}
+	${common.build_flags_sensors}
 	${common.build_flags_wifi}
+	${common.build_flags_ha}
 
-[env:uno_r4_wifi]
-platform = renesas-ra
-framework = arduino
-board = uno_r4_wifi
-lib_deps = ${common.lib_deps}
-build_flags = 
-	${common.build_flags}
-	${common.build_flags_wifi}
-; needed for WiFi sublibraries to be found correctly
-lib_ldf_mode = deep+
+; The ci_validation_x configs exist to test that code works with only one sensor.
+; Two environments to test that one works without the other.
+[env:ci_validation_1]
+extends = env:leonardo
+build_flags = ${common.build_flags} -DSENSORS_LIGHT_PIN=A0
+
+[env:ci_validation_2]
+extends = env:leonardo
+build_flags = ${common.build_flags} -DHAVE_AHT20=1
 
 ; To be restored once we actually create tests
 ; [env:native]

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -22,7 +22,9 @@ FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)()) : ens160(&Wire, 
 FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)())
 #endif
 {
+#ifdef HAVE_FLOW
   this->sen0217InterruptHandler = sen0217InterruptHandler;
+#endif
 }
 
 FuFarmSensors::~FuFarmSensors()


### PR DESCRIPTION
Fixes #9 

By default, the code has all sensors enabled to just be sure they all fit together nicely and without errors and mistakes or collisions. However, there is are many more scenarios where only one sensor may be in use and that needs validation.

PlatformIO does not natively support loading extra environment variables in its tools. It would be cool but needs a special/custom python script which is too much at this time. A simpler solution was just adding a new environment. To avoid building for that scenario exclusively, a second environment is setup with a different sensor.

As a result of this, an error in configuration of `sen0217InterruptHandler` was discovered.

Also, the environment variable `CI` is set so that PlatformIO CLI can discover it.