### PR TITLE
Simpler logic for SEN0217 interrupts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,8 +11,7 @@
 
 #define BUFFER_SIZE 256
 
-extern void sen0217InterruptHandler(); // defined later in the file
-FuFarmSensors sensors(sen0217InterruptHandler);
+FuFarmSensors sensors;
 FuFarmSensorsData sensorsData;
 static boolean calibrationMode = false;
 
@@ -28,13 +27,6 @@ PubSubClient client(wifiClient);
 #else
 StaticJsonDocument<200> doc;
 #endif
-
-void sen0217InterruptHandler() // this exists because there is no way to pass an instance method to the interrupt
-{
-#ifdef HAVE_FLOW
-  sensors.sen0217Interrupt();
-#endif
-}
 
 #if HAVE_WIFI
 void printMacAddress(byte mac[])

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -16,19 +16,30 @@
 
 #define KVALUEADDR 0x00
 
+FuFarmSensors* FuFarmSensors::_instance = nullptr;
+
+#ifdef HAVE_FLOW
+static void sen0217InterruptHandler()
+{
+  // An instance will always exist because the interrupt is attached when an instance method is called.
+  // There is therefore no need to check if it is null.
+  // The function is also static meaning it cannot be referenced outside this file.
+  FuFarmSensors::instance()->sen0217Interrupt();
+}
+#endif
+
 #ifdef HAVE_ENS160
-FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)()) : ens160(&Wire, /* I2C Address */ 0x53)
+FuFarmSensors::FuFarmSensors() : ens160(&Wire, /* I2C Address */ 0x53)
 #else
-FuFarmSensors::FuFarmSensors(void (*sen0217InterruptHandler)())
+FuFarmSensors::FuFarmSensors()
 #endif
 {
-#ifdef HAVE_FLOW
-  this->sen0217InterruptHandler = sen0217InterruptHandler;
-#endif
+  _instance = this;
 }
 
 FuFarmSensors::~FuFarmSensors()
 {
+  _instance = nullptr;
 }
 
 void FuFarmSensors::begin()
@@ -77,10 +88,7 @@ void FuFarmSensors::begin()
 
 #ifdef HAVE_FLOW
   pulseCount = 0;
-  if (sen0217InterruptHandler != nullptr)
-  {
-    attachInterrupt(digitalPinToInterrupt(SENSORS_SEN0217_PIN), sen0217InterruptHandler, RISING);
-  }
+  attachInterrupt(digitalPinToInterrupt(SENSORS_SEN0217_PIN), sen0217InterruptHandler, RISING);
 #endif
 
 #ifdef HAVE_EC

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -63,12 +63,18 @@ struct FuFarmSensorsData
 class FuFarmSensors
 {
 public:
-  FuFarmSensors(void (*sen0217InterruptHandler)() = nullptr);
+  FuFarmSensors();
   ~FuFarmSensors();
   void begin();                                           // initialization
   void calibration(unsigned long readIntervalMs = 1000U); // calibration, should be called in a loop, ideally a config mode
   void read(FuFarmSensorsData *dest);                     // read all sensor data
   void sen0217Interrupt();                                // should be called from the interrupt handler passed in the constructor
+
+  /**
+   * Returns existing instance (singleton) of the FuFarmSensors class.
+   * It may be a null pointer if the FuFarmSensors object was never constructed or it was destroyed.
+   */
+  inline static FuFarmSensors *instance() { return _instance; }
 
 private:
 #ifdef HAVE_DHT22
@@ -95,7 +101,6 @@ private:
 
 #ifdef HAVE_FLOW
   volatile int pulseCount; // Flow Sensor
-  void (*sen0217InterruptHandler)();
 #endif
 
 private:
@@ -114,6 +119,9 @@ private:
   bool cmdSerialDataAvailable();
   char *strupr(char *str);
   uint16_t convertENS160AQItoHA(uint8_t indexRaw);
+
+  /// Living instance of the FuFarmSensors class. It can be nullptr.
+  static FuFarmSensors *_instance;
 };
 
 #endif // SENSORS_H


### PR DESCRIPTION
Following works in https://github.com/farm-urban/fufarm_arduino_sensors/pull/26, it seems it would be easier to keep logic for sensors mostly inside the files for sensors. This now makes use of a static instance of `FuFarmSensors` when handling the interrupt. Consequently, there is no need to pass a pointer to a function even when not in use.