### PR TITLE
Moved Home Assistant logic to own files and use library

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ There are a number of sensors used in the farm for different purposes.
 | Sensor   | Purpose                        | Pin | Flag                 | Macro                  |
 | -------- | ------------------------------ | --- | -------------------- | ---------------------- |
 | Light    |                                | A0  | SENSORS_LIGHT_PIN    | HAVE_LIGHT             |
-| C02      |                                | A1  | SENSORS_CO2_PIN      | HAVE_CO2               |
+| CO2      |                                | A1  | SENSORS_CO2_PIN      | HAVE_CO2               |
 | EC       |                                | A2  | SENSORS_EC_PIN       | HAVE_EC                |
 | pH       |                                | A3  | SENSORS_PH_PIN       | HAVE_PH                |
 | Moisture |                                | A4  | SENSORS_MOISTURE_PIN | HAVE_MOISTURE          |
@@ -125,7 +125,7 @@ If your machine is connected to a different network it does not allow incoming t
 Forwarding                    tcp://6.tcp.eu.ngrok.io:14333 -> localhost:1883
 ```
 
-You can then change your `platformio.ini` settings to match this. In this case, `-DHOME_ASSISTANT_MQTT_SERVER_IP=\"6.tcp.eu.ngrok.io\"` and `-DHOME_ASSISTANT_MQTT_SERVER_PORT=14333`.
+You can then change your `platformio.ini` settings to match this. In this case, `-DHOME_ASSISTANT_MQTT_HOST=\"6.tcp.eu.ngrok.io\"` and `-DHOME_ASSISTANT_MQTT_PORT=14333`.
 
 </details>
 <br/>
@@ -139,20 +139,15 @@ Once you upload, the code and the connection happens, in the mosquitto window yo
 1742675822: Opening ipv6 listen socket on port 1883.
 1742675822: Opening ipv4 listen socket on port 1883.
 1742675822: mosquitto version 2.0.21 running
-1742675849: New connection from ::1:61910 on port 1883.
-1742675849: New client connected from ::1:61910 as ard1 (p2, c1, k90).
-1742675849: No will message specified.
-1742675849: Sending CONNACK to ard1 (0, 0)
-1742675849: Received PUBLISH from ard1 (d0, q0, r1, m0, 'homeassistant/sensor/ard1_illuminance/config', ... (171 bytes))
-1742675849: Received DISCONNECT from ard1
-1742675849: Client ard1 disconnected.
-1742675849: New connection from ::1:61911 on port 1883.
-1742675849: New client connected from ::1:61911 as ard1 (p2, c1, k90).
-1742675849: No will message specified.
-1742675849: Sending CONNACK to ard1 (0, 0)
-1742675849: Received PUBLISH from ard1 (d0, q0, r1, m0, 'homeassistant/sensor/ard1_illuminance/state', ... (3 bytes))
-1742675849: Received DISCONNECT from ard1
-1742675849: Client ard1 disconnected.
+1742756031: New connection from ::1:54640 on port 1883.
+1742756031: New client connected from ::1:54640 as 48ca435e0080 (p2, c1, k90).
+1742756031: No will message specified.
+1742756031: Sending CONNACK to 48ca435e0080 (0, 0)
+1742756031: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/temperature/config', ... (205 bytes))
+1742756032: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/humidity/config', ... (196 bytes))
+1742756032: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/aqi/config', ... (181 bytes))
+1742756032: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/tvoc/config', ... (212 bytes))
+1742756033: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/eco2/config', ... (194 bytes))
 ```
 </details>
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@ lib_deps =
 	https://github.com/DFRobot/DFRobot_PH.git
 	knolleary/PubSubClient@2.8
 	bblanchon/ArduinoJson@6.21.3
+	dawidchyrzynski/home-assistant-integration@2.1.0
 build_flags = 
 	; sample time in milliseconds (60k = 60seconds or 1 minute)
 	-DSAMPLE_WINDOW_MILLIS=60000
@@ -35,11 +36,13 @@ build_flags_sensors =
 	-DHAVE_ENS160=1
 	-DCALIBRATION_TOGGLE_PIN=12
 build_flags_ha = 
-	-DHOME_ASSISTANT_MQTT_SERVER_IP=\"192.168.8.100\"
-	-DHOME_ASSISTANT_MQTT_SERVER_PORT=1883
-	-DHOME_ASSISTANT_MQTT_CLIENT_ID=\"ard1\"
-	; -DHOME_ASSISTANT_MQTT_USER=\"ard1\"
+	; Debugging for HA is enabled for easier visibility into what is happening in the library
+	-DARDUINOHA_DEBUG
+	-DHOME_ASSISTANT_MQTT_HOST=\"192.168.8.100\"
+	-DHOME_ASSISTANT_MQTT_PORT=1883
+	; -DHOME_ASSISTANT_MQTT_USERNAME=\"ard1\"
 	; -DHOME_ASSISTANT_MQTT_PASSWORD=\"0\"
+	-DHOME_ASSISTANT_DEVICE_NAME=\"ard1\"
 build_flags_wifi = 
 	-DWIFI_SSID=\"fumanc\"
 	; -DWIFI_SSID=\"ASK4\ Wireless\"

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -143,6 +143,9 @@ void FuFarmHomeAssistant::setValues(FuFarmSensorsData *source)
   tvoc.setValue(source->airQuality.tvoc);
   eco2.setValue(source->airQuality.eco2);
 #endif
+#ifdef HAVE_FLOW
+  flow.setValue(source->flow);
+#endif
 #ifdef HAVE_TEMP_WET
   liquidtemp.setValue(source->temperature.wet);
 #endif

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -1,0 +1,163 @@
+#include "HomeAssistant.h"
+
+#if USE_HOME_ASSISTANT
+
+#ifndef HOME_ASSISTANT_MQTT_USERNAME
+#define HOME_ASSISTANT_MQTT_USERNAME nullptr
+#endif
+
+#ifndef HOME_ASSISTANT_MQTT_PASSWORD
+#define HOME_ASSISTANT_MQTT_PASSWORD nullptr
+#endif
+
+FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
+// The strings being passed in constructors are the sensor identifiers.
+// They should be unique for the device and are required by the library.
+// We can probably find a better source but this works for the moment.
+#ifdef HAVE_WATER_LEVEL_STATE
+  waterLevel("waterLevel"),
+#endif
+#ifdef HAVE_LIGHT
+  light("light"),
+#endif
+#if defined(HAVE_DHT22) || defined(HAVE_AHT20)
+  temperature("temperature"), humidity("humidity"),
+#endif
+#ifdef HAVE_ENS160
+  aqi("aqi"), tvoc("tvoc"), eco2("eco2"),
+#endif
+#ifdef HAVE_FLOW
+  flow("flow"),
+#endif
+#ifdef HAVE_TEMP_WET
+  liquidtemp("liquidtemp"),
+#endif
+#ifdef HAVE_CO2
+  co2("co2"),
+#endif
+#ifdef HAVE_EC
+  ec("ec"),
+#endif
+#ifdef HAVE_PH
+  ph("ph"),
+#endif
+#ifdef HAVE_MOISTURE
+  moisture("moisture"),
+#endif
+  mqtt(client, device)
+{
+  // set device's details
+  device.setName(HOME_ASSISTANT_DEVICE_NAME);
+  device.setSoftwareVersion(HOME_ASSISTANT_DEVICE_SOFTWARE_VERSION);
+#ifdef HOME_ASSISTANT_DEVICE_MANUFACTURER
+  device.setManufacturer(HOME_ASSISTANT_DEVICE_MANUFACTURER);
+#endif
+#ifdef HOME_ASSISTANT_DEVICE_MODEL
+  device.setModel(HOME_ASSISTANT_DEVICE_MODEL);
+#endif
+
+  // set MQTT properties
+  mqtt.setDiscoveryPrefix(HOME_ASSISTANT_DISCOVERY_PREFIX);
+  mqtt.setDataPrefix(HOME_ASSISTANT_DATA_PREFIX);
+  mqtt.setKeepAlive(HOME_ASSISTANT_MQTT_KEEPALIVE);
+
+  // Setup sensors with the relevant information
+  // Device classes are listed at https://www.home-assistant.io/integrations/sensor/#device-class
+#ifdef HAVE_WATER_LEVEL_STATE
+  // TODO: find a better device class for this
+  waterLevel.setDeviceClass("moisture");
+#endif
+#ifdef HAVE_LIGHT
+  light.setDeviceClass("illuminance");
+#endif
+#if defined(HAVE_DHT22) || defined(HAVE_AHT20)
+  temperature.setDeviceClass("temperature");
+  humidity.setDeviceClass("humidity");
+#endif
+#ifdef HAVE_ENS160
+  aqi.setDeviceClass("aqi");
+  tvoc.setDeviceClass("volatile_organic_compounds_parts");
+  eco2.setDeviceClass("carbon_dioxide");
+#endif
+#ifdef HAVE_FLOW
+  flow.setDeviceClass("volume_flow_rate");
+#endif
+#ifdef HAVE_TEMP_WET
+  liquidtemp.setDeviceClass("temperature");
+#endif
+#ifdef HAVE_CO2
+  co2.setDeviceClass("carbon_dioxide");
+#endif
+#ifdef HAVE_EC
+  ec.setDeviceClass("ec");
+#endif
+#ifdef HAVE_PH
+  ph.setDeviceClass("ph");
+#endif
+#ifdef HAVE_MOISTURE
+  moisture.setDeviceClass("moisture");
+#endif
+}
+
+FuFarmHomeAssistant::~FuFarmHomeAssistant()
+{
+}
+
+void FuFarmHomeAssistant::setUniqueDeviceId(const uint8_t *value, uint8_t length)
+{
+  device.setUniqueId(value, length);
+}
+
+void FuFarmHomeAssistant::begin()
+{
+  begin(HOME_ASSISTANT_MQTT_HOST,
+        HOME_ASSISTANT_MQTT_PORT,
+        HOME_ASSISTANT_MQTT_USERNAME,
+        HOME_ASSISTANT_MQTT_PASSWORD);
+}
+
+void FuFarmHomeAssistant::begin(const char *host, const uint16_t port, const char *username, const char *password)
+{
+  mqtt.begin(host, port, username, password);
+}
+
+void FuFarmHomeAssistant::maintain()
+{
+  mqtt.loop();
+}
+
+void FuFarmHomeAssistant::setValues(FuFarmSensorsData *source)
+{
+#ifdef HAVE_WATER_LEVEL_STATE
+  waterLevel.setState(source->waterLevelState);
+#endif
+#ifdef HAVE_LIGHT
+  light.setValue(source->light);
+#endif
+#if defined(HAVE_DHT22) || defined(HAVE_AHT20)
+  temperature.setValue(source->temperature.air);
+  humidity.setValue(source->humidity);
+#endif
+#ifdef HAVE_ENS160
+  aqi.setValue(source->airQuality.index);
+  tvoc.setValue(source->airQuality.tvoc);
+  eco2.setValue(source->airQuality.eco2);
+#endif
+#ifdef HAVE_TEMP_WET
+  liquidtemp.setValue(source->temperature.wet);
+#endif
+#ifdef HAVE_CO2
+  co2.setValue(source->co2);
+#endif
+#ifdef HAVE_EC
+  ec.setValue(source->ec);
+#endif
+#ifdef HAVE_PH
+  ph.setValue(source->ph);
+#endif
+#ifdef HAVE_MOISTURE
+  moisture.setValue(source->moisture);
+#endif
+}
+
+#endif // USE_HOME_ASSISTANT

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -145,40 +145,40 @@ void FuFarmHomeAssistant::maintain()
   mqtt.loop();
 }
 
-void FuFarmHomeAssistant::setValues(FuFarmSensorsData *source)
+void FuFarmHomeAssistant::setValues(FuFarmSensorsData *source, const bool force)
 {
 #ifdef HAVE_WATER_LEVEL_STATE
-  waterLevel.setState(source->waterLevelState);
+  waterLevel.setState(source->waterLevelState, force);
 #endif
 #ifdef HAVE_LIGHT
-  light.setValue(source->light);
+  light.setValue(source->light, force);
 #endif
 #if defined(HAVE_DHT22) || defined(HAVE_AHT20)
-  temperature.setValue(source->temperature.air);
-  humidity.setValue(source->humidity);
+  temperature.setValue(source->temperature.air, force);
+  humidity.setValue(source->humidity, force);
 #endif
 #ifdef HAVE_ENS160
-  aqi.setValue(source->airQuality.index);
-  tvoc.setValue(source->airQuality.tvoc);
-  eco2.setValue(source->airQuality.eco2);
+  aqi.setValue(source->airQuality.index, force);
+  tvoc.setValue(source->airQuality.tvoc, force);
+  eco2.setValue(source->airQuality.eco2, force);
 #endif
 #ifdef HAVE_FLOW
-  flow.setValue(source->flow);
+  flow.setValue(source->flow, force);
 #endif
 #ifdef HAVE_TEMP_WET
-  liquidtemp.setValue(source->temperature.wet);
+  liquidtemp.setValue(source->temperature.wet, force);
 #endif
 #ifdef HAVE_CO2
-  co2.setValue(source->co2);
+  co2.setValue(source->co2, force);
 #endif
 #ifdef HAVE_EC
-  ec.setValue(source->ec);
+  ec.setValue(source->ec, force);
 #endif
 #ifdef HAVE_PH
-  ph.setValue(source->ph);
+  ph.setValue(source->ph, force);
 #endif
 #ifdef HAVE_MOISTURE
-  moisture.setValue(source->moisture);
+  moisture.setValue(source->moisture, force);
 #endif
 }
 

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -10,6 +10,9 @@
 #define HOME_ASSISTANT_MQTT_PASSWORD nullptr
 #endif
 
+#define EXPIRE_AFTER_SECONDS ((SAMPLE_WINDOW_MILLIS * 2) / 1000)
+#define SET_EXPIRE_AFTER(sensor) sensor.setExpireAfter(EXPIRE_AFTER_SECONDS)
+
 FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
 // The strings being passed in constructors are the sensor identifiers.
 // They should be unique for the device and are required by the library.
@@ -66,36 +69,52 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
 #ifdef HAVE_WATER_LEVEL_STATE
   // TODO: find a better device class for this
   waterLevel.setDeviceClass("moisture");
+  waterLevel.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_LIGHT
   light.setDeviceClass("illuminance");
+  light.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #if defined(HAVE_DHT22) || defined(HAVE_AHT20)
   temperature.setDeviceClass("temperature");
+  temperature.setExpireAfter(EXPIRE_AFTER_SECONDS);
+
   humidity.setDeviceClass("humidity");
+  humidity.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_ENS160
   aqi.setDeviceClass("aqi");
+  aqi.setExpireAfter(EXPIRE_AFTER_SECONDS);
+
   tvoc.setDeviceClass("volatile_organic_compounds_parts");
+  tvoc.setExpireAfter(EXPIRE_AFTER_SECONDS);
+
   eco2.setDeviceClass("carbon_dioxide");
+  eco2.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_FLOW
   flow.setDeviceClass("volume_flow_rate");
+  flow.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_TEMP_WET
   liquidtemp.setDeviceClass("temperature");
+  liquidtemp.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_CO2
   co2.setDeviceClass("carbon_dioxide");
+  co2.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_EC
   ec.setDeviceClass("ec");
+  ec.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_PH
   ph.setDeviceClass("ph");
+  ph.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_MOISTURE
   moisture.setDeviceClass("moisture");
+  moisture.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 }
 

--- a/src/HomeAssistant.h
+++ b/src/HomeAssistant.h
@@ -72,8 +72,9 @@ public:
    * be the same from time to time.
    *
    * @param source All values for configured sensors.
+   * @param force Forces to update the state without comparing it to a previous known state.
    */
-  void setValues(FuFarmSensorsData *source);
+  void setValues(FuFarmSensorsData *source, const bool force = true);
 
 private:
   HADevice device;

--- a/src/HomeAssistant.h
+++ b/src/HomeAssistant.h
@@ -1,0 +1,117 @@
+#include "config.h"
+
+#ifndef HOME_ASSISTANT_H
+#define HOME_ASSISTANT_H
+
+#if USE_HOME_ASSISTANT
+
+#include <ArduinoHA.h>
+#include "sensors.h"
+
+class FuFarmHomeAssistant
+{
+public:
+  /**
+   * Creates a new instance of the FuFarmHomeAssistant class.
+   * Please note that only one instance of the class can be initialized at the same time.
+   *
+   * @param client The Etherclient or WiFiClient that's going to be used for the network communication.
+   */
+  FuFarmHomeAssistant(Client &client);
+
+  /**
+   * Cleanup resources created and managed by the FuFarmHomeAssistant class.
+   */
+  ~FuFarmHomeAssistant();
+
+  /**
+   * Returns pointer to the unique ID. It can be nullptr if the device has no ID assigned.
+   */
+  inline const char *getUniqueId() const { return device.getUniqueId(); }
+
+  /**
+   * Sets unique ID of the device based on the given byte array.
+   * Each byte is converted into a hex string representation, so the final length of the unique ID will be twice as given.
+   *
+   * @param uniqueId Bytes array that's going to be converted into the string.
+   * @param length Number of bytes in the array.
+   */
+  void setUniqueDeviceId(const uint8_t *value, uint8_t length);
+
+  /**
+   * Sets parameters of the MQTT connection using the IP address and port.
+   * Connection to the broker will be done in the first loop cycle.
+   * This class automatically reconnects to the broker if connection is lost.
+   *
+   * Connection parameters (host, port, username, password, etc) are pulled from the build flags.
+   */
+  void begin();
+
+  /**
+   * Sets parameters of the MQTT connection using the IP address and port.
+   * Connection to the broker will be done in the first loop cycle.
+   * This class automatically reconnects to the broker if connection is lost.
+   *
+   * @param host Domain or IP address of the MQTT broker.
+   * @param port Port of the MQTT broker.
+   * @param username Username for authentication. It can be nullptr if the anonymous connection needs to be performed.
+   * @param password Password for authentication. It can be nullptr if the anonymous connection needs to be performed.
+   */
+  void begin(const char *host, const uint16_t port = 1883, const char *username = nullptr, const char *password = nullptr);
+
+  /**
+   * This method should be called periodically inside the main loop of the firmware.
+   * It's safe to call this method in some interval (like 5ms).
+   */
+  void maintain();
+
+  /**
+   * Publishes MQTT messages for configured sensors.
+   * In some cases, if a sensor value is the same as the previous one the MQTT message won't be published.
+   * It means that MQTT messages will produced each time the setValues method is called but they might not
+   * be the same from time to time.
+   *
+   * @param source All values for configured sensors.
+   */
+  void setValues(FuFarmSensorsData *source);
+
+private:
+  HADevice device;
+  HAMqtt mqtt;
+
+private:
+#ifdef HAVE_WATER_LEVEL_STATE
+  HABinarySensor waterLevel;
+#endif
+#ifdef HAVE_LIGHT
+  HASensorNumber light;
+#endif
+#if defined(HAVE_DHT22) || defined(HAVE_AHT20)
+  HASensorNumber temperature, humidity;
+#endif
+#ifdef HAVE_ENS160
+  HASensorNumber aqi, tvoc, eco2;
+#endif
+#ifdef HAVE_FLOW
+  HASensorNumber flow;
+#endif
+#ifdef HAVE_TEMP_WET
+  HASensorNumber liquidtemp;
+#endif
+#ifdef HAVE_CO2
+  HASensorNumber co2;
+#endif
+#ifdef HAVE_EC
+  HASensorNumber ec;
+#endif
+#ifdef HAVE_PH
+  HASensorNumber ph;
+#endif
+#ifdef HAVE_MOISTURE
+  HASensorNumber moisture;
+#endif
+};
+
+#endif // USE_HOME_ASSISTANT
+
+#endif // HOME_ASSISTANT_H

--- a/src/config.h
+++ b/src/config.h
@@ -1,7 +1,8 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-// #define MOCK ; // Uncomment to skip wifi connection for testing sensors
+// // Uncomment to skip WiFi connection for testing sensors
+// #define HAVE_WIFI 0
 
 #ifdef SENSORS_LIGHT_PIN
   #define HAVE_LIGHT
@@ -85,16 +86,17 @@
     !defined(HAVE_MOISTURE) && !defined(HAVE_DHT22) && \
     !defined(HAVE_FLOW) && !defined(HAVE_TEMP_WET) && \
     !defined(HAVE_WATER_LEVEL_STATE) && !defined(HAVE_AHT20) && \
-    !defined(HAVE_ENS160) && \
-    !defined(MOCK)
-  #error "At least one sensor must be configured unless mocking"
+    !defined(HAVE_ENS160)
+  #error "At least one sensor must be configured"
 #endif
 
 // WiFi
-#if defined(ARDUINO_AVR_LEONARDO)
-  #define HAVE_WIFI 0
-#elif defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_AVR_UNO_WIFI_REV2)
+#ifndef HAVE_WIFI
+#if defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_AVR_UNO_WIFI_REV2)
   #define HAVE_WIFI 1
+#else
+  #define HAVE_WIFI 0
+#endif
 #endif
 
 #if (defined(WIFI_ENTERPRISE_USERNAME) && !defined(WIFI_ENTERPRISE_PASSWORD)) || \
@@ -116,7 +118,18 @@
 #endif
 
 // Home Assistant
-#ifndef HOME_ASSISTANT_MQTT_KEEPALIVE
+#if HAVE_WIFI
+  #define USE_HOME_ASSISTANT 1
+#else
+  #define USE_HOME_ASSISTANT 0
+#endif
+
+#if USE_HOME_ASSISTANT
+  #define HOME_ASSISTANT_DEVICE_SOFTWARE_VERSION "0.1.0"
+	#define HOME_ASSISTANT_DEVICE_MANUFACTURER "Farm Urban"
+	#define HOME_ASSISTANT_DEVICE_MODEL "Distributed Farm"
+  #define HOME_ASSISTANT_DISCOVERY_PREFIX "homeassistant"
+  #define HOME_ASSISTANT_DATA_PREFIX "homeassistant"
   #define HOME_ASSISTANT_MQTT_KEEPALIVE 90
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,15 +1,12 @@
 #include "config.h"
 
-#if defined(ARDUINO_UNOR4_WIFI)
-#include <WiFiS3.h>
-#elif defined(ARDUINO_AVR_UNO_WIFI_REV2)
-#include <WiFiNINA.h>
+#if HAVE_WIFI
+#include <WiFi.h>
+#else
+#include <ArduinoJson.h>
 #endif
 
-#include <ArduinoJson.h>
 #include "sensors.h"
-
-#define BUFFER_SIZE 256
 
 FuFarmSensors sensors;
 FuFarmSensorsData sensorsData;
@@ -17,13 +14,11 @@ static boolean calibrationMode = false;
 
 // Wifi control
 #if HAVE_WIFI
-#include <PubSubClient.h>
+#include "HomeAssistant.h"
 
-String HA_DISCOVERY_PREFIX = "homeassistant";
-String MQTT_CLIENT_ID(HOME_ASSISTANT_MQTT_CLIENT_ID);
 int wifiStatus = WL_IDLE_STATUS; // the Wifi radio's status
 WiFiClient wifiClient;
-PubSubClient client(wifiClient);
+FuFarmHomeAssistant ha(wifiClient);
 #else
 StaticJsonDocument<200> doc;
 #endif
@@ -119,10 +114,6 @@ void listNetworks() {
 
 void connectToWifi()
 {
-#ifdef MOCK
-  Serial.println("Skipping connectToWifi");
-  return;
-#endif
   if (WiFi.status() == WL_CONNECTED)
   {
     Serial.println("connectToWifi - already connected");
@@ -163,188 +154,14 @@ void connectToWifi()
 
 void shutdownWifi()
 {
-#ifdef MOCK
-  Serial.println("Skipping shutdownWifi");
-  return;
-#endif
   Serial.println("*** shutdownWifi ***");
   WiFi.disconnect();
   WiFi.end();
-}
-
-String haSensorName(String name){
-  String sensor_name = MQTT_CLIENT_ID + "_" + name;
-  return sensor_name;
-}
-
-String haSensorTopic(String name, String type, bool isBinary){
-  String sensor_name = haSensorName(name);
-  String sensor_prefix = isBinary ? "binary_sensor" : "sensor";
-  String topic = HA_DISCOVERY_PREFIX + "/" + sensor_prefix + "/" + sensor_name + "/" + type;
-  return topic;
-}
-
-void haAnnounceSensor(String name, String type, bool isBinary, JsonDocument& payload, char buffer[]){
-  String sensor_name = haSensorName(name);
-  String config_topic = haSensorTopic(name, "config", isBinary);
-  String state_topic = haSensorTopic(name, "state", isBinary);
-  payload["name"] = sensor_name;
-  payload["device_class"] = type; // https://www.home-assistant.io/integrations/sensor/#device-class
-  payload["state_topic"] = state_topic;
-  payload["unique_id"] = sensor_name;
-  // payload["unit_of_measurement"] = measurement;
-  payload["expire_after"] = (String)(SAMPLE_WINDOW_MILLIS * 2);
-  serializeJson(payload, buffer, BUFFER_SIZE);
-  String info = "Announcing sensor: " + config_topic + "\n" + buffer;
-  Serial.println(info);
-  client.publish(config_topic.c_str(), buffer, true);
-  payload.clear();
-}
-
-void haRegisterSensors() {
-  StaticJsonDocument<200> payload;
-  char buffer[BUFFER_SIZE];
-#ifdef HAVE_WATER_LEVEL_STATE
-  // https://www.home-assistant.io/integrations/binary_sensor/
-  haAnnounceSensor(String("water_level"), String("moisture"), true, payload, buffer);
-#endif
-#ifdef HAVE_LIGHT
-  haAnnounceSensor(String("illuminance"), String("illuminance"), false, payload, buffer);
-#endif
-#if defined(HAVE_DHT22) || defined(HAVE_AHT20)
-  haAnnounceSensor(String("temperature"), String("temperature"), false, payload, buffer);
-  haAnnounceSensor(String("humidity"), String("humidity"), false, payload, buffer);
-#endif
-#if defined(HAVE_ENS160)
-  haAnnounceSensor(String("aqi"), String("aqi"), false, payload, buffer);
-  haAnnounceSensor(String("tvoc"), String("volatile_organic_compounds_parts"), false, payload, buffer);
-  haAnnounceSensor(String("ec02"), String("carbon_dioxide"), false, payload, buffer);
-#endif
-#ifdef HAVE_FLOW
-  haAnnounceSensor(String("volume_flow_rate"), String("volume_flow_rate"), false, payload, buffer);
-#endif
-#ifdef HAVE_TEMP_WET
-  haAnnounceSensor(String("liquidtemp"), String("temperature"), false, payload, buffer);
-#endif
-#ifdef HAVE_CO2
-  haAnnounceSensor(String("carbon_dioxide"), String("carbon_dioxide"), false, payload, buffer);
-#endif
-#ifdef HAVE_EC
-  haAnnounceSensor(String("ec"), String("ec"), false, payload, buffer);
-#endif
-#ifdef HAVE_PH
-  haAnnounceSensor(String("ph"), String("ph"), false, payload, buffer);
-#endif
-#ifdef HAVE_MOISTURE
-  haAnnounceSensor(String("moisture"), String("moisture"), false, payload, buffer);
-#endif
-}
-
-void haPublishSensor(String name, bool isBinary, String value){
-  String topic = haSensorTopic(name, "state", isBinary);
-  String info = "Publishing sensor: " + topic + " : " + value;
-  Serial.println(info);
-#ifndef MOCK
-  client.publish(topic.c_str(), value.c_str(), true);
-#endif // MOCK
-}
-
-  void haPublishData(FuFarmSensorsData *data) {
-    String value = "";
-    String sensor = "";
-#ifdef HAVE_WATER_LEVEL_STATE
-    sensor = "water_level";
-    value = data->waterLevelState ? "ON" : "OFF";
-    haPublishSensor(sensor, true, value);
-#endif
-#ifdef HAVE_LIGHT
-    sensor = "illuminance";
-    value = (String)data->light;
-    haPublishSensor(sensor, false, value);
-#endif
-#if defined(HAVE_DHT22) || defined(HAVE_AHT20)
-    sensor = "temperature";
-    value = (String)data->temperature.air;
-    haPublishSensor(sensor, false, value);
-    sensor = "humidity";
-    value = (String)data->humidity;
-    haPublishSensor(sensor, false, value);
-#endif
-#if defined(HAVE_ENS160)
-    sensor = "aqi";
-    value = (String)sensorsData.airQuality.index;
-    haPublishSensor(sensor, false, value);
-    sensor = "tvoc";
-    value = (String)data->airQuality.tvoc;
-    haPublishSensor(sensor, false, value);
-    sensor = "ec02";
-    value = (String)data->airQuality.eco2;
-    haPublishSensor(sensor, false, value);
-#endif
-
-#ifdef HAVE_FLOW
-    sensor = "volume_flow_rate";
-    value = (String)data->flow;
-    haPublishSensor(sensor, false, value);
-#endif
-#ifdef HAVE_TEMP_WET
-  sensor = "tempwet";
-  value = (String)data->temperature.wet;
-  haPublishSensor(sensor, false, value);
-#endif
-#ifdef HAVE_CO2
-  sensor = "carbon_dioxide";
-  value = (String)data->co2;
-  haPublishSensor(sensor, false, value);
-#endif
-#ifdef HAVE_EC
-  sensor = "ec";
-  value = (String)data->ec;
-  haPublishSensor(sensor, false, value);
-#endif
-#ifdef HAVE_PH
-  sensor = "ph";
-  value = (String)data->ph;
-  haPublishSensor(sensor, false, value);
-#endif
-#ifdef HAVE_MOISTURE
-  sensor = "moisture";
-  value = (String)data->moisture;
-  haPublishSensor(sensor, false, value);
-#endif
-    }
-
-
-void reconnect() {
-  // Loop until we're reconnected
-  while (!client.connected()) {
-    Serial.println("INFO: Attempting MQTT connection...");
-    // Attempt to connect
-    client.setKeepAlive(HOME_ASSISTANT_MQTT_KEEPALIVE);
-#ifdef HOME_ASSISTANT_MQTT_USER
-    bool connected = client.connect(HOME_ASSISTANT_MQTT_CLIENT_ID, HOME_ASSISTANT_MQTT_USER, HOME_ASSISTANT_MQTT_PASSWORD);
-#else
-    bool connected = client.connect(HOME_ASSISTANT_MQTT_CLIENT_ID);
-#endif
-    if (connected)
-    {
-      Serial.println("INFO: connected");
-    }
-    else
-    {
-      Serial.print("ERROR: failed, rc=");
-      Serial.println(client.state());
-      Serial.println("DEBUG: try again in 5 seconds");
-      // Wait 5 seconds before retrying
-      delay(5000);
-    }
-  }
 }
 #endif // HAVE_WIFI
 
 void setup()
 {
-  // pinMode(LED_BUILTIN, OUTPUT);
   Serial.begin(9600);
 
   // https://www.arduino.cc/reference/en/language/functions/analog-io/analogreference/
@@ -352,11 +169,11 @@ void setup()
   analogReference(DEFAULT); // Set the default voltage of the reference voltage
 #elif defined(ARDUINO_UNOR4_WIFI)
   analogReference(AR_DEFAULT); // AR_DEFAULT: 5V on the Uno R4 WiFi
-  analogReadResolution(14); //change to 14-bit resolution
+  analogReadResolution(14);    // change to 14-bit resolution
 #elif defined(ARDUINO_AVR_UNO_WIFI_REV2)
   analogReference(VDD); // VDD: Vdd of the ATmega4809. 5V on the Uno WiFi Rev2
 #else // any other board we have not validated
-  #pragma message "⚠️ Unable to set analogue reference voltage. Board not supported."
+#pragma message "⚠️ Unable to set analogue reference voltage. Board not supported."
 #endif
 
   sensors.begin();
@@ -376,12 +193,12 @@ void setup()
     Serial.println(F("enterec -> enter the calibration mode"));
     Serial.println(F("calec   -> calibrate with the standard buffer solution, two buffer solutions(1413us/cm and 12.88ms/cm) will be automatically recognized"));
     Serial.println(F("exitec  -> save the calibrated parameters and exit from calibration mode"));
+    return; // no further initialization can happen when in calibration mode
   } else {
     Serial.println(F("Assuming sensors have been calibrated. To enter calibration mode, short the calibration toggle and reset."));
   }
 #endif
 
-#ifndef MOCK
 #if HAVE_WIFI
   // check for the WiFi module:
   if (WiFi.status() == WL_NO_MODULE)
@@ -397,18 +214,17 @@ void setup()
   }
   connectToWifi();
 
-  // init the MQTT connection
-  client.setServer(HOME_ASSISTANT_MQTT_SERVER_IP, HOME_ASSISTANT_MQTT_SERVER_PORT);
-  // client.setCallback(callback);
-  if (!client.connected()) {
-    reconnect();
-  }
-  client.loop();
-  haRegisterSensors();
-  client.disconnect();
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  ha.setUniqueDeviceId(mac, sizeof(mac));
+  Serial.print("Home Assistant Unique Device ID: ");
+  Serial.println(ha.getUniqueId());
+  ha.begin();
+
 #endif // HAVE_WIFI
-#endif // MOCK
 } // end setup
+
+static unsigned long timepoint = millis();
 
 void loop()
 {
@@ -417,78 +233,61 @@ void loop()
     return; // nothing else can happen when in calibration mode
   }
 
-  // Serial.println("Starting main loop");
-  // digitalWrite(LED_BUILTIN, HIGH);
-
-#ifdef ARDUINO_AVR_UNO_WIFI_REV2
-  connectToWifi();
-#endif
-
-  sensors.read(&sensorsData);
-
+  if ((millis() - timepoint) >= SAMPLE_WINDOW_MILLIS) {
+    timepoint = millis();
+    sensors.read(&sensorsData);
 #if HAVE_WIFI
-#ifndef MOCK
-  if (!client.connected()) {
-    reconnect();
-  }
-  client.loop();
-#endif // MOCK
-  haPublishData(&sensorsData);
-#ifndef MOCK
-  Serial.println("INFO: Closing the MQTT connection");
-  client.disconnect();
-#endif // MOCK
-#endif // HAVE_WIFI
-
-
-#ifdef ARDUINO_AVR_UNO_WIFI_REV2
-  //   // If no Wifi signal, try to reconnect it
-  //  if ((WiFi.RSSI() == 0) && (wifiMulti.run() != WL_CONNECTED)) {
-  //    Serial.println("Wifi connection lost");
-  //  }
-  // Need to shutdown wifi due to bug in Wifi: https://github.com/arduino-libraries/WiFiNINA/issues/103 | https://github.com/arduino-libraries/WiFiNINA/issues/207
-  shutdownWifi();
-#endif
-#if HAVE_WIFI
+    ha.setValues(&sensorsData);
+    // TODO: this logic keeps disconnecting so we need to improve it (fix: only scan in setup to avoid different status)
+    connectToWifi();
 #else
-  // populate json
+    // populate json
 #if defined(HAVE_DHT22) || defined(HAVE_AHT20)
-  doc["tempair"] = sensorsData.temperature.air;
-  doc["humidity"] = sensorsData.humidity;
+    doc["tempair"] = sensorsData.temperature.air;
+    doc["humidity"] = sensorsData.humidity;
 #endif
 #ifdef HAVE_ENS160
-  doc["aqi"] = sensorsData.airQuality.index;
-  doc["tvoc"] = sensorsData.airQuality.tvoc;
-  doc["ec02"] = sensorsData.airQuality.eco2;
+    doc["aqi"] = sensorsData.airQuality.index;
+    doc["tvoc"] = sensorsData.airQuality.tvoc;
+    doc["eco2"] = sensorsData.airQuality.eco2;
 #endif
 #ifdef HAVE_TEMP_WET
-  doc["tempwet"] = sensorsData.temperature.wet;
+    doc["tempwet"] = sensorsData.temperature.wet;
 #endif
-#ifdef HAVE_C02
-  doc["co2"] = sensorsData.co2;
+#ifdef HAVE_CO2
+    doc["co2"] = sensorsData.co2;
 #endif
 #ifdef HAVE_EC
-  doc["ec"] = sensorsData.ec;
+    doc["ec"] = sensorsData.ec;
 #endif
 #ifdef HAVE_PH
-  doc["ph"] = sensorsData.ph;
+    doc["ph"] = sensorsData.ph;
 #endif
 #ifdef HAVE_FLOW
-  doc["flow"] = sensorsData.flow;
+    doc["flow"] = sensorsData.flow;
 #endif
 #ifdef HAVE_LIGHT
-  doc["light"] = sensorsData.light;
+    doc["light"] = sensorsData.light;
 #endif
 #ifdef HAVE_MOISTURE
-  doc["moisture"] = sensorsData.moisture;
+    doc["moisture"] = sensorsData.moisture;
 #endif
 #ifdef HAVE_WATER_LEVEL_STATE
-  doc["water_level"] = sensorsData.waterLevelState;
+    doc["water_level"] = sensorsData.waterLevelState;
 #endif
 
-  serializeJson(doc, Serial);
-  Serial.println();
-  Serial.flush();
+    serializeJson(doc, Serial);
+    Serial.println();
+    Serial.flush();
 #endif
-  delay(SAMPLE_WINDOW_MILLIS);
-} // end loop
+  }
+
+#if HAVE_WIFI
+  ha.maintain();
+#endif // HAVE_WIFI
+
+  // This delay should be short so that the networking stuff is maintained correctly.
+  // Network maintenance includes checking for WiFi connection, server connection, and sending PINGs.
+  // Updating of sensor values happens over a longer delay by checking elapsed time above.
+  delay(500);
+}

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -274,17 +274,17 @@ bool FuFarmSensors::readWaterLevelState()
 #endif
 }
 
-int FuFarmSensors::readLight()
+int32_t FuFarmSensors::readLight()
 {
 #ifdef HAVE_LIGHT
   float voltage = ANALOG_READ_MILLI_VOLTS(SENSORS_LIGHT_PIN);
-  return (int)(voltage / 10.0);
+  return (int32_t)(voltage / 10.0);
 #else
   return -1;
 #endif
 }
 
-int FuFarmSensors::readCO2()
+int32_t FuFarmSensors::readCO2()
 {
 #ifdef HAVE_CO2
   // Calculate CO2 concentration in ppm
@@ -296,7 +296,7 @@ int FuFarmSensors::readCO2()
   else
   {
     float voltage_difference = voltage - 400.0;
-    return (int)(voltage_difference * 50.0 / 16.0);
+    return (int32_t)(voltage_difference * 50.0 / 16.0);
   }
 #else
   return -1;
@@ -340,14 +340,14 @@ float FuFarmSensors::readFlow()
 #endif
 }
 
-int FuFarmSensors::readMoisture()
+int32_t FuFarmSensors::readMoisture()
 {
 #ifdef HAVE_MOISTURE
   // Need to calibrate this
   int dry = 587;
   int wet = 84;
   int reading = analogRead(SENSORS_MOISTURE_PIN);
-  return (int)(100.0 * (dry - reading) / (dry - wet));
+  return (int32_t)(100.0 * (dry - reading) / (dry - wet));
 #else
   return -1;
 #endif

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -31,10 +31,10 @@
 
 struct FuFarmSensorsData
 {
-  int light;
+  int32_t light;
   float humidity;
   float flow;
-  int co2;
+  int32_t co2;
   struct FuFarmSensorsTemperature
   {
     float air;
@@ -42,7 +42,7 @@ struct FuFarmSensorsData
   } temperature;
   float ec;
   float ph;
-  int moisture;
+  int32_t moisture;
   bool waterLevelState;
   struct FuFarmSensorsAirQuality
   {
@@ -104,12 +104,12 @@ private:
 #endif
 
 private:
-  int readLight();
-  int readCO2();
+  int32_t readLight();
+  int32_t readCO2();
   float readEC(float temperature);
   float readPH(float temperature);
   float readFlow();
-  int readMoisture();
+  int32_t readMoisture();
   float readTempWet();
   bool readWaterLevelState();
 


### PR DESCRIPTION
This moves the code for Home Assistant from `main.cpp` to `HomeAssistant.{h,cpp}` which continues the maintainability effort.

In so doing, it created an avenue for simplification by using the `dawidchyrzynski/home-assistant-integration` library which has support for more features (more sensors) and we do not have to build much of the logic needed. It also handles reconnection to the server.

The device/chip mac address is now used as its unique identifier. It gets converted to HEX but it will be in reverse order as compared to a MAC e.g. MAC printed as `80:00:5E:43:CA:48` will be device `48ca435e0080` and topics looking like `homeassistant/sensor/48ca435e0080/light/config` This unique identifier is printed on startup.

This opens up the possibility of having sensors sending data at different times such as when using an RTOS, timer or interrupts. We could also send commands to toggle a fan, pump, or open a valve using `HAButton`.

Also
1. fixed C02 -> CO2 and eC02 -> eCO2
2. Use fixed length integers to avoid ambiguity where multiple overloads are available
3. Simpler logic for mock by forcing `HAVE_WIFI=0`

> [!NOTE]
> This is a heavy change. Tests done by someone else would be useful too.
> WiFi still has a bug which I have fixed in another branch.