### PR TITLE
Adding a manager for WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,20 +134,17 @@ Once you upload, the code and the connection happens, in the mosquitto window yo
 <details>
 <summary>Console output</summary>
 ```txt
-1742675822: mosquitto version 2.0.21 starting
-1742675822: Config loaded from mosquitto.conf.
-1742675822: Opening ipv6 listen socket on port 1883.
-1742675822: Opening ipv4 listen socket on port 1883.
-1742675822: mosquitto version 2.0.21 running
-1742756031: New connection from ::1:54640 on port 1883.
-1742756031: New client connected from ::1:54640 as 48ca435e0080 (p2, c1, k90).
-1742756031: No will message specified.
-1742756031: Sending CONNACK to 48ca435e0080 (0, 0)
-1742756031: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/temperature/config', ... (205 bytes))
-1742756032: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/humidity/config', ... (196 bytes))
-1742756032: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/aqi/config', ... (181 bytes))
-1742756032: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/tvoc/config', ... (212 bytes))
-1742756033: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/eco2/config', ... (194 bytes))
+1742759640: mosquitto version 2.0.21 starting
+1742759640: Config loaded from mosquitto.conf.
+1742759640: Opening ipv6 listen socket on port 1883.
+1742759640: Opening ipv4 listen socket on port 1883.
+1742759640: mosquitto version 2.0.21 running
+1742759655: New connection from ::1:56091 on port 1883.
+1742759655: New client connected from ::1:56091 as 48ca435e0080 (p2, c1, k90).
+1742759655: No will message specified.
+1742759655: Sending CONNACK to 48ca435e0080 (0, 0)
+1742759655: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/sensor/48ca435e0080/light/config', ... (193 bytes))
+1742759655: Received PUBLISH from 48ca435e0080 (d0, q0, r1, m0, 'homeassistant/48ca435e0080/light/stat_t', ... (3 bytes))
 ```
 </details>
 

--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -1,0 +1,173 @@
+#include "WiFiManager.h"
+
+#if HAVE_WIFI
+
+WiFiManager::WiFiManager()
+{
+}
+
+WiFiManager::~WiFiManager()
+{
+}
+
+void WiFiManager::begin()
+{
+  // check if the WiFi module is present
+  if (WiFi.status() == WL_NO_MODULE)
+  {
+    Serial.println("Communication with WiFi module failed!");
+    while (true)
+      ; // don't continue
+  }
+
+  // check firmware version of the module
+  String fv = WiFi.firmwareVersion();
+  if (fv < WIFI_FIRMWARE_LATEST_VERSION)
+  {
+    Serial.println("Please upgrade the firmware");
+  }
+
+  WiFi.disconnect(); // Clear network stack https://forum.arduino.cc/t/mqtt-with-esp32-gives-timeout-exceeded-disconnecting/688723/5
+
+  listNetworks();
+
+  connect();
+}
+
+void WiFiManager::maintain()
+{
+  connect();
+}
+
+void WiFiManager::printMacAddress(uint8_t mac[])
+{
+  for (int i = 5; i >= 0; i--)
+  {
+    if (mac[i] < 16)
+    {
+      Serial.print("0");
+    }
+    Serial.print(mac[i], HEX);
+    if (i > 0)
+    {
+      Serial.print(":");
+    }
+  }
+}
+
+void WiFiManager::printEncryptionType(uint8_t type)
+{
+  // read the encryption type and print out the name:
+  switch (type)
+  {
+  case ENC_TYPE_WEP:
+    Serial.println("WEP");
+    break;
+  case ENC_TYPE_TKIP:
+    Serial.println("WPA");
+    break;
+  case ENC_TYPE_CCMP:
+    Serial.println("WPA2");
+    break;
+  case ENC_TYPE_NONE:
+    Serial.println("None");
+    break;
+  case ENC_TYPE_AUTO:
+    Serial.println("Auto");
+    break;
+  case ENC_TYPE_UNKNOWN:
+  default:
+    Serial.println("Unknown");
+    break;
+  }
+}
+
+void WiFiManager::listNetworks()
+{
+  Serial.println("** Scan Networks **");
+  int8_t count = WiFi.scanNetworks();
+  if (count == -1)
+  {
+    Serial.println("Couldn't scan for WiFi networks");
+    return; // nothing more to do here
+  }
+
+  Serial.print("Number of available networks: ");
+  Serial.println(count);
+  for (int8_t i = 0; i < count; i++)
+  {
+    Serial.print(i);
+    Serial.print(") ");
+    Serial.print(WiFi.SSID(i));
+    Serial.print("\tSignal: ");
+    Serial.print(WiFi.RSSI(i));
+    Serial.print(" dBm");
+    Serial.print("\tEncryption: ");
+    printEncryptionType(WiFi.encryptionType(i));
+  }
+  Serial.println();
+}
+
+void WiFiManager::connect()
+{
+  // if already connected, there is nothing more to do
+  uint8_t status = WiFi.status();
+  if (status == WL_CONNECTED)
+  {
+    return;
+  }
+
+  // detect disconnection
+  if (_status != status)
+  {
+    Serial.println("WiFi disconnected");
+  }
+
+  Serial.print("Attempting to connect to WiFi SSID: ");
+  Serial.println(WIFI_SSID);
+
+#if defined(WIFI_ENTERPRISE_USERNAME) && defined(WIFI_ENTERPRISE_PASSWORD)
+  status = WiFi.beginEnterprise(WIFI_SSID,
+                                WIFI_ENTERPRISE_USERNAME,
+                                WIFI_ENTERPRISE_PASSWORD,
+                                WIFI_ENTERPRISE_IDENTITY,
+                                WIFI_ENTERPRISE_CA);
+#elif defined(WIFI_PASSPHRASE)
+  status = WiFi.begin(WIFI_SSID, WIFI_PASSPHRASE);
+#else
+  status = WiFi.begin(WIFI_SSID);
+#endif
+
+  while (status != WL_CONNECTED)
+  {
+    delay(500);
+    Serial.print(".");
+    status = WiFi.status();
+  }
+  _status = WL_CONNECTED;
+
+  Serial.println();
+  Serial.println("WiFi connected successfully!");
+  Serial.print("SSID: ");
+  Serial.println(WiFi.SSID());
+
+  uint8_t mac[WL_MAC_ADDR_LENGTH];
+  WiFi.BSSID(mac);
+  Serial.print("BSSID: ");
+  printMacAddress(mac);
+  Serial.println();
+
+  Serial.print("Signal strength (RSSI): ");
+  Serial.print(WiFi.RSSI());
+  Serial.println(" dBm");
+
+  Serial.print("IP Address: ");
+  Serial.println(WiFi.localIP());
+
+  WiFi.macAddress(mac);
+  Serial.print("MAC address: ");
+  printMacAddress(mac);
+  Serial.println();
+}
+
+#endif // HAVE_WIFI

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -1,0 +1,47 @@
+#include "config.h"
+
+#ifndef WIFI_MANAGER_H
+#define WIFI_MANAGER_H
+
+#if HAVE_WIFI
+
+#include <WiFi.h>
+
+class WiFiManager
+{
+public:
+  /**
+   * Creates a new instance of the WiFiManager class.
+   * Please note that only one instance of the class can be initialized at the same time.
+   */
+  WiFiManager();
+
+  /**
+   * Cleanup resources created and managed by the WiFiManager class.
+   */
+  ~WiFiManager();
+
+  /**
+   * Scan for networks and connect to the one known
+   */
+  void begin();
+
+  /**
+   * This method should be called periodically inside the main loop of the firmware.
+   * It's safe to call this method in some interval (like 5ms).
+   */
+  void maintain();
+
+private:
+  uint8_t _status;
+
+private:
+  void printMacAddress(uint8_t mac[]);
+  void printEncryptionType(uint8_t type);
+  void listNetworks();
+  void connect();
+};
+
+#endif // HAVE_WIFI
+
+#endif // WIFI_MANAGER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,12 @@
 #include "config.h"
+#include "sensors.h"
 
 #if HAVE_WIFI
-#include <WiFi.h>
+#include "HomeAssistant.h"
+#include "WiFiManager.h"
 #else
 #include <ArduinoJson.h>
 #endif
-
-#include "sensors.h"
 
 FuFarmSensors sensors;
 FuFarmSensorsData sensorsData;
@@ -14,151 +14,12 @@ static boolean calibrationMode = false;
 
 // Wifi control
 #if HAVE_WIFI
-#include "HomeAssistant.h"
-
-int wifiStatus = WL_IDLE_STATUS; // the Wifi radio's status
+WiFiManager wifiManager;
 WiFiClient wifiClient;
 FuFarmHomeAssistant ha(wifiClient);
 #else
 StaticJsonDocument<200> doc;
 #endif
-
-#if HAVE_WIFI
-void printMacAddress(byte mac[])
-{
-  for (int i = 5; i >= 0; i--)
-  {
-    if (mac[i] < 16)
-    {
-      Serial.print("0");
-    }
-    Serial.print(mac[i], HEX);
-    if (i > 0)
-    {
-      Serial.print(":");
-    }
-  }
-  Serial.println();
-}
-
-void printCurrentNet()
-{
-  Serial.println("Currently connected to network");
-  Serial.print("SSID: ");
-  Serial.println(WiFi.SSID());
-  byte bssid[6];
-  WiFi.BSSID(bssid);
-  Serial.print("BSSID: ");
-  printMacAddress(bssid);
-  long rssi = WiFi.RSSI();
-  Serial.print("signal strength (RSSI):");
-  Serial.println(rssi);
-  byte encryption = WiFi.encryptionType();
-  Serial.print("Encryption Type:");
-  Serial.println(encryption, HEX);
-  Serial.println();
-  IPAddress ip = WiFi.localIP();
-  Serial.print("IP Address: ");
-  Serial.println(ip);
-  byte mac[6];
-  WiFi.macAddress(mac);
-  Serial.print("MAC address: ");
-  printMacAddress(mac);
-}
-
-void printEncryptionType(int thisType) {
-  // read the encryption type and print out the name:
-  switch (thisType) {
-    case ENC_TYPE_WEP:
-      Serial.println("WEP");
-      break;
-    case ENC_TYPE_TKIP:
-      Serial.println("WPA");
-      break;
-    case ENC_TYPE_CCMP:
-      Serial.println("WPA2");
-      break;
-    case ENC_TYPE_NONE:
-      Serial.println("None");
-      break;
-    case ENC_TYPE_AUTO:
-      Serial.println("Auto");
-      break;
-    case ENC_TYPE_UNKNOWN:
-    default:
-      Serial.println("Unknown");
-      break;
-  }
-}
-
-void listNetworks() {
-  Serial.println("** Scan Networks **");
-  int numSsid = WiFi.scanNetworks();
-  if (numSsid == -1) {
-    Serial.println("Couldn't get a WiFi connection");
-    while (true);
-  }
-  Serial.print("Number of available networks: ");
-  Serial.println(numSsid);
-  for (int thisNet = 0; thisNet < numSsid; thisNet++) {
-    Serial.print(thisNet);
-    Serial.print(") ");
-    Serial.print(WiFi.SSID(thisNet));
-    Serial.print("\tSignal: ");
-    Serial.print(WiFi.RSSI(thisNet));
-    Serial.print(" dBm");
-    Serial.print("\tEncryption: ");
-    printEncryptionType(WiFi.encryptionType(thisNet));
-  }
-}
-
-void connectToWifi()
-{
-  if (WiFi.status() == WL_CONNECTED)
-  {
-    Serial.println("connectToWifi - already connected");
-    return;
-  }
-  wifiStatus = WL_IDLE_STATUS;
-  int attempts = 0;
-  while (wifiStatus != WL_CONNECTED)
-  {
-    listNetworks(); // Printing this after connecting to the Wifi causes the client connection to fail. WTAF.
-    Serial.println();
-    if (attempts > 0){
-      Serial.print("Failed to connect on attempt:");
-      Serial.print(attempts);
-      Serial.print(" - reason:");
-      Serial.println(WiFi.reasonCode()); // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-reason-code
-      Serial.println();
-    }
-    Serial.print("Attempting to connect to WPA SSID: ");
-    Serial.println(WIFI_SSID);
-    WiFi.disconnect(); // Clear network stack https://forum.arduino.cc/t/mqtt-with-esp32-gives-timeout-exceeded-disconnecting/688723/5
-#if defined(WIFI_ENTERPRISE_USERNAME) && defined(WIFI_ENTERPRISE_PASSWORD)
-    wifiStatus = WiFi.beginEnterprise(WIFI_SSID,
-                                      WIFI_ENTERPRISE_USERNAME,
-                                      WIFI_ENTERPRISE_PASSWORD,
-                                      WIFI_ENTERPRISE_IDENTITY,
-                                      WIFI_ENTERPRISE_CA);
-#elif defined(WIFI_PASSPHRASE)
-    wifiStatus = WiFi.begin(WIFI_SSID, WIFI_PASSPHRASE);
-#else
-    wifiStatus = WiFi.begin(WIFI_SSID);
-#endif
-    delay(10000);
-    attempts++;
-  }
-  printCurrentNet();
-}
-
-void shutdownWifi()
-{
-  Serial.println("*** shutdownWifi ***");
-  WiFi.disconnect();
-  WiFi.end();
-}
-#endif // HAVE_WIFI
 
 void setup()
 {
@@ -182,7 +43,8 @@ void setup()
 #ifdef SUPPORTS_CALIBRATION
   pinMode(CALIBRATION_TOGGLE_PIN, INPUT_PULLUP);
   calibrationMode = digitalRead(CALIBRATION_TOGGLE_PIN) == 0;
-  if (calibrationMode) {
+  if (calibrationMode)
+  {
     Serial.println(F("Calibration toggle has been shorted hence enter calibration mode. To exit, remove the short and reset."));
     Serial.println(F("EC and PH sensors take calibration commands via Serial Monitor/Terminal."));
     Serial.println(F("Available commands for PH sensor:"));
@@ -194,25 +56,15 @@ void setup()
     Serial.println(F("calec   -> calibrate with the standard buffer solution, two buffer solutions(1413us/cm and 12.88ms/cm) will be automatically recognized"));
     Serial.println(F("exitec  -> save the calibrated parameters and exit from calibration mode"));
     return; // no further initialization can happen when in calibration mode
-  } else {
+  }
+  else
+  {
     Serial.println(F("Assuming sensors have been calibrated. To enter calibration mode, short the calibration toggle and reset."));
   }
 #endif
 
 #if HAVE_WIFI
-  // check for the WiFi module:
-  if (WiFi.status() == WL_NO_MODULE)
-  {
-    Serial.println("Communication with WiFi module failed!");
-    while (true)
-      ; // don't continue
-  }
-  String fv = WiFi.firmwareVersion();
-  if (fv < WIFI_FIRMWARE_LATEST_VERSION)
-  {
-    Serial.println("Please upgrade the firmware");
-  }
-  connectToWifi();
+  wifiManager.begin();
 
   uint8_t mac[6];
   WiFi.macAddress(mac);
@@ -228,18 +80,18 @@ static unsigned long timepoint = millis();
 
 void loop()
 {
-  if (calibrationMode) {
+  if (calibrationMode)
+  {
     sensors.calibration();
     return; // nothing else can happen when in calibration mode
   }
 
-  if ((millis() - timepoint) >= SAMPLE_WINDOW_MILLIS) {
+  if ((millis() - timepoint) >= SAMPLE_WINDOW_MILLIS)
+  {
     timepoint = millis();
     sensors.read(&sensorsData);
 #if HAVE_WIFI
     ha.setValues(&sensorsData);
-    // TODO: this logic keeps disconnecting so we need to improve it (fix: only scan in setup to avoid different status)
-    connectToWifi();
 #else
     // populate json
 #if defined(HAVE_DHT22) || defined(HAVE_AHT20)
@@ -283,6 +135,7 @@ void loop()
   }
 
 #if HAVE_WIFI
+  wifiManager.maintain();
   ha.maintain();
 #endif // HAVE_WIFI
 

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -1,6 +1,7 @@
 #ifndef SENSORS_H
 #define SENSORS_H
 
+#include <stdint.h>
 #include "config.h"
 
 #ifdef HAVE_EC


### PR DESCRIPTION
The WiFi connection maybe severed at one time such as when a hotspot looses power or if a phone call comes in when tethering. The manager for WiFi connection will reconnect to the network when it becomes available.

With this:
1. Reconnection no loner happens every time in the loop because we only scan for networks at the start of the program.
2. Connection to a network no longer takes 10 seconds. We have a 0.5s period for checking connection received. When the network is stable (e.g. at the office), it may take less than 5 seconds to be send first transmission.
3. The `main.cpp` files seems to get cleaner. We can support Ethernet or Cellular without much burden if needed. Also support for other WiFi boards will be easier.
4. The disconnection logs for WiFi and HomeAssistant may appear at separate times but that should not be an issue.