### PR TITLE
Add support for ESP32 S3 DevKitC 1 N16R8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Create firmware folder
         run: |
           mkdir -p firmware
+          cp ${{ github.workspace }}/.pio/build/esp32-s3-devkitc-1-n16r8v/firmware.elf ${{ github.workspace }}/firmware/esp32-s3-devkitc-1-n16r8v.elf
+          cp ${{ github.workspace }}/.pio/build/esp32-s3-devkitc-1-n16r8v/firmware.bin ${{ github.workspace }}/firmware/esp32-s3-devkitc-1-n16r8v.bin
           cp ${{ github.workspace }}/.pio/build/leonardo/firmware.elf ${{ github.workspace }}/firmware/leonardo.elf
           cp ${{ github.workspace }}/.pio/build/leonardo/firmware.hex ${{ github.workspace }}/firmware/leonardo.hex
           cp ${{ github.workspace }}/.pio/build/uno_r4_wifi/firmware.elf ${{ github.workspace }}/firmware/uno_r4_wifi.elf

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This code is built for the following boards:
 - [Arduino Leonardo](https://store.arduino.cc/products/arduino-leonardo-with-headers)
 - [Arduino UNO R4 WiFi](https://store.arduino.cc/products/uno-r4-wifi)
 - [Arduino UNO WiFi R2](https://store.arduino.cc/products/arduino-uno-wifi-rev2)
+- [ESP32 S3 DevKitC 1 N16R8](https://www.amazon.co.uk/ESP32-DevKitC-WROOM1-Development-Bluetooth/dp/B0CLD4QKT1)
 
 Other boards might be added with time, if need be. However, should you need to test on another board, [supported by PlatformIO](https://docs.platformio.org/en/latest/boards/index.html), the easiest way would be to add a new environment in the [platformio.ini](./platformio.ini) file. The current code base is built to work with Arduino which means choosing boards [supported by the Arduino platform](https://docs.platformio.org/en/latest/frameworks/arduino.html#boards) is easier.
 

--- a/boards/esp32-s3-devkitc-1-n16r8v.json
+++ b/boards/esp32-s3-devkitc-1-n16r8v.json
@@ -1,0 +1,53 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif ESP32-S3-DevKitC-1-N16R8V (16 MB QD, 8MB PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [common]
 lib_deps = 
 	beegee-tokyo/DHT sensor library for ESPx@1.18
-	paulstoffregen/OneWire@2.3.5
+	https://github.com/PaulStoffregen/OneWire.git@2.3.8
 	https://github.com/DFRobot/DFRobot_AHT20.git
 	https://github.com/DFRobot/DFRobot_EC.git
 	https://github.com/DFRobot/DFRobot_ENS160.git
@@ -57,10 +57,23 @@ build_flags_wifi =
 ; a command override using --environment/-e options
 ; Comment/uncomment, one of the lines to target just one which is easier/faster for local use.
 [platformio]
+; default_envs = esp32-s3-devkitc-1-n16r8v
 ; default_envs = leonardo
 ; default_envs = uno_r4_wifi
 ; default_envs = uno_wifi_rev2
-default_envs = leonardo, uno_r4_wifi, uno_wifi_rev2, ci_validation_1, ci_validation_2
+default_envs = esp32-s3-devkitc-1-n16r8v, leonardo, uno_r4_wifi, uno_wifi_rev2, ci_validation_1, ci_validation_2
+
+; Similar to the Arduino Nano ESP32 (https://store.arduino.cc/products/nano-esp32) but cheaper and with more memory
+[env:esp32-s3-devkitc-1-n16r8v]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+framework = arduino
+board = esp32-s3-devkitc-1-n16r8v
+lib_deps = ${common.lib_deps}
+build_flags = 
+	${common.build_flags}
+	${common.build_flags_sensors}
+	${common.build_flags_wifi}
+	${common.build_flags_ha}
 
 [env:leonardo]
 platform = atmelavr

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -36,8 +36,9 @@ private:
   uint8_t _status;
 
 private:
+#ifndef ARDUINO_ESP32S3_DEV
   void printMacAddress(uint8_t mac[]);
-  void printEncryptionType(uint8_t type);
+#endif
   void listNetworks();
   void connect();
 };

--- a/src/config.h
+++ b/src/config.h
@@ -34,7 +34,8 @@
   // For this flow sensor, only interrupt pins should be used. Configured on a rising edge
   // https://reference.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/
 
-  #if defined(ARDUINO_AVR_LEONARDO) // only 0, 1, 2, 3, 7
+  #if defined(ARDUINO_ESP32S3_DEV) // all pins
+  #elif defined(ARDUINO_AVR_LEONARDO) // only 0, 1, 2, 3, 7
     #if SENSORS_SEN0217_PIN == 0
     #elif SENSORS_SEN0217_PIN == 1
     #elif SENSORS_SEN0217_PIN == 2
@@ -92,7 +93,7 @@
 
 // WiFi
 #ifndef HAVE_WIFI
-#if defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_AVR_UNO_WIFI_REV2)
+#if defined(ARDUINO_ESP32S3_DEV) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_AVR_UNO_WIFI_REV2)
   #define HAVE_WIFI 1
 #else
   #define HAVE_WIFI 0
@@ -113,7 +114,7 @@
 
 #if defined(ARDUINO_UNOR4_WIFI)
   #if defined(WIFI_ENTERPRISE_USERNAME) || defined(WIFI_ENTERPRISE_PASSWORD)
-    #error "Arduino Uno R4 WiFi (via WiFiS3 library) does not support enterprise WiFi."
+    #error "Arduino Uno R4 WiFi does not yes support enterprise WiFi."
   #endif
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,10 @@ void setup()
   Serial.begin(9600);
 
   // https://www.arduino.cc/reference/en/language/functions/analog-io/analogreference/
-#if defined(ARDUINO_AVR_LEONARDO)
+#if defined(ARDUINO_ESP32S3_DEV)
+  // no need to set the reference voltage on ESP32-S3 because it offers reads in millivolts
+  analogReadResolution(12); // change to 12-bit resolution
+#elif defined(ARDUINO_AVR_LEONARDO)
   analogReference(DEFAULT); // Set the default voltage of the reference voltage
 #elif defined(ARDUINO_UNOR4_WIFI)
   analogReference(AR_DEFAULT); // AR_DEFAULT: 5V on the Uno R4 WiFi

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -4,15 +4,22 @@
 
 // Will be different depending on the reference voltage.
 // We use float to avoid integer overflow.
-#ifdef ARDUINO_UNOR4_WIFI
+#if defined(ARDUINO_ESP32S3_DEV)
+// nothing to set there because it supports reading in millivolts
+#elif defined(ARDUINO_UNOR4_WIFI)
 #define ANALOG_REFERENCE_MILLI_VOLTS 5000.0f
 #define ANALOG_MAX_VALUE 16384 // 14 bit ADC
 #else
 #define ANALOG_REFERENCE_MILLI_VOLTS 5000.0f
 #define ANALOG_MAX_VALUE 1024 // 10 bit ADC
 #endif
+
 // to avoid possible loss of precision, multiply before dividing
+#if defined(ARDUINO_ESP32S3_DEV)
+#define ANALOG_READ_MILLI_VOLTS(pin) (analogReadMilliVolts(pin))
+#else
 #define ANALOG_READ_MILLI_VOLTS(pin) ((analogRead(pin) * ANALOG_REFERENCE_MILLI_VOLTS) / ANALOG_MAX_VALUE)
+#endif
 
 #define KVALUEADDR 0x00
 


### PR DESCRIPTION
This board is similar to the [Arduino Nano ESP32](https://store.arduino.cc/products/nano-esp32) but [cheaper](https://www.amazon.co.uk/ESP32-DevKitC-WROOM1-Development-Bluetooth/dp/B0CLD4QKT1) and with [more memory](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html). PlatformIO does not have the board supported by default, waiting on https://github.com/platformio/platform-espressif32/issues/989, but thankfully we can make our [own board](https://docs.platformio.org/en/latest/platforms/creating_board.html) without bloating platformio.ini.

Benefits:
1. There being no module means less quirks with module firmware. For example, connecting to a WiFi network containing spaces works, including MQTT connection. Enterprise WiFi is a breeze too.
2. Similar to the Arduino Nano ESP32 but has more RAM.
3. Analogue read is simplified: no need to convert to millivolts manually.