### PR TITLE
Add missing pin mode setting for SEN0217

### DIFF
--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -88,6 +88,7 @@ void FuFarmSensors::begin()
 
 #ifdef HAVE_FLOW
   pulseCount = 0;
+  pinMode(SENSORS_SEN0217_PIN, INPUT);
   attachInterrupt(digitalPinToInterrupt(SENSORS_SEN0217_PIN), sen0217InterruptHandler, RISING);
 #endif
 


### PR DESCRIPTION
In some cases, without the pinMode, it results to in a warning. According to the [docs](https://www.arduino.cc/reference/cs/language/functions/external-interrupts/attachinterrupt/), it should be called before `attachInterrupt(...)`