### PR TITLE
Ignore libraries that are not used based on board

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ You can comment/uncomment, one of the lines under `platformio` in the configurat
 
 | Name/Action                   | Command Format                                        | Example                                               |
 | ----------------------------- | ----------------------------------------------------- | ----------------------------------------------------- |
-| Build (default environments)  |                                                       | `pio run`                                             |
-| Build (specific environment)  | `pio run --environment {env-name}`                    | `pio run --environment uno_wifi_rev2`                 |
-| Upload (specific environment) | `pio run --environment {env-name} --target upload`    | `pio run --environment uno_wifi_rev2 --target upload` |
-| Test                          |                                                       | `pio test --environment native`                       |
-| Clean (default environments)n |                                                       | `pio run --target fullclean`                          |
-| Clean (specific environment)  | `pio run --environment {env-name} --target fullclean` | `pio run --environment leonardo --target fullclean`   |
+| Build (default boards)  |                                                       | `pio run`                                             |
+| Build (specific board)  | `pio run --environment {env-name}`                    | `pio run --environment uno_wifi_rev2`                 |
+| Upload (specific board) | `pio run --environment {env-name} --target upload`    | `pio run --environment uno_wifi_rev2 --target upload` |
+| Test                    |                                                       | `pio test --environment native`                       |
+| Clean (default boards)n |                                                       | `pio run --target fullclean`                          |
+| Clean (specific board)  | `pio run --environment {env-name} --target fullclean` | `pio run --environment leonardo --target fullclean`   |
 
 ## WiFi
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,6 @@ lib_deps =
 	https://github.com/DFRobot/DFRobot_ENS160.git
 	https://github.com/DFRobot/DFRobot_PH.git
 	knolleary/PubSubClient@2.8
-	bblanchon/ArduinoJson@6.21.3
 	dawidchyrzynski/home-assistant-integration@2.1.0
 build_flags = 
 	; sample time in milliseconds (60k = 60seconds or 1 minute)
@@ -79,7 +78,11 @@ build_flags =
 platform = atmelavr
 framework = arduino
 board = leonardo
-lib_deps = ${common.lib_deps}
+lib_deps = 
+	${common.lib_deps}
+	bblanchon/ArduinoJson@6.21.3
+lib_deps_ignore = 
+	dawidchyrzynski/home-assistant-integration
 build_flags = 
 	${common.build_flags}
 	${common.build_flags_sensors}

--- a/src/config.h
+++ b/src/config.h
@@ -69,7 +69,7 @@
   #define SUPPORTS_CALIBRATION
 #endif
 
-// Validation of the build configuration
+// Validation of the sensor selection
 #if !defined(HAVE_TEMP_WET) && (defined(HAVE_EC) || defined(HAVE_PH))
   #pragma message "⚠️ Without DS18S20 (wet temperature), calibration of EC and PH sensors is done using air temperature which may not be as accurate!"
 #endif


### PR DESCRIPTION
On the Leonardo, we do not need the Home Assistant library. Similarly, only the Leonardo needs the JSON library, so it should only be installed for that board. This is similar to how we install `WiFiNINA` only on the `uno_wifi_rev2` board.