### PR TITLE
Home Assistant Improvements (classes, units, icons, names)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,6 @@
 *.exe
 *.out
 *.app
+
 .DS_Store
+.venv

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -70,11 +70,11 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
 #ifdef HAVE_WATER_LEVEL_STATE
   waterLevel.setDeviceClass("moisture");
   waterLevel.setIcon("mdi:cup-water");
-  waterLevel.setName("Water Tank Level");
+  waterLevel.setName("Sump Level Indicator");
   waterLevel.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_LIGHT
-  // TODO: the sensor we are using does not support lux, we need to consider using a custom class
+  // TODO: the sensor we are using does not support lux, we may want to consider using a custom class
   light.setDeviceClass("illuminance");
   light.setUnitOfMeasurement("lx");
   light.setExpireAfter(EXPIRE_AFTER_SECONDS);
@@ -104,6 +104,7 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
 #endif
 #ifdef HAVE_FLOW
   flow.setDeviceClass("volume_flow_rate");
+  flow.setIcon("mdi:waves-arrow-right"); // default icon is unknown so we set ours
   flow.setUnitOfMeasurement("L/min");
   flow.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -67,8 +67,9 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
   // Setup sensors with the relevant information
   // Device classes are listed at https://www.home-assistant.io/integrations/sensor/#device-class
 #ifdef HAVE_WATER_LEVEL_STATE
-  // TODO: find a better device class for this
   waterLevel.setDeviceClass("moisture");
+  waterLevel.setIcon("mdi:cup-water");
+  waterLevel.setName("Water Tank Level");
   waterLevel.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_LIGHT
@@ -96,6 +97,7 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
   tvoc.setExpireAfter(EXPIRE_AFTER_SECONDS);
 
   eco2.setDeviceClass("carbon_dioxide");
+  eco2.setName("Carbon Dioxide (Equivalent)");
   eco2.setUnitOfMeasurement("ppm");
   eco2.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
@@ -106,6 +108,7 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
 #endif
 #ifdef HAVE_TEMP_WET
   liquidtemp.setDeviceClass("temperature");
+  liquidtemp.setName("Liquid Temperature");
   liquidtemp.setUnitOfMeasurement("°C");
   liquidtemp.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -72,40 +72,51 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
   waterLevel.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_LIGHT
+  // TODO: the sensor we are using does not support lux, we need to consider using a custom class
   light.setDeviceClass("illuminance");
+  light.setUnitOfMeasurement("lx");
   light.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #if defined(HAVE_DHT22) || defined(HAVE_AHT20)
   temperature.setDeviceClass("temperature");
+  temperature.setUnitOfMeasurement("°C");
   temperature.setExpireAfter(EXPIRE_AFTER_SECONDS);
 
   humidity.setDeviceClass("humidity");
+  humidity.setUnitOfMeasurement("%");
   humidity.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_ENS160
   aqi.setDeviceClass("aqi");
   aqi.setExpireAfter(EXPIRE_AFTER_SECONDS);
+  // no need to set unit for AQI, it is documented as unitless
 
   tvoc.setDeviceClass("volatile_organic_compounds_parts");
+  tvoc.setUnitOfMeasurement("ppb");
   tvoc.setExpireAfter(EXPIRE_AFTER_SECONDS);
 
   eco2.setDeviceClass("carbon_dioxide");
+  eco2.setUnitOfMeasurement("ppm");
   eco2.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_FLOW
   flow.setDeviceClass("volume_flow_rate");
+  flow.setUnitOfMeasurement("L/min");
   flow.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_TEMP_WET
   liquidtemp.setDeviceClass("temperature");
+  liquidtemp.setUnitOfMeasurement("°C");
   liquidtemp.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_CO2
   co2.setDeviceClass("carbon_dioxide");
+  co2.setUnitOfMeasurement("ppm");
   co2.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_EC
   ec.setDeviceClass("ec");
+  ec.setUnitOfMeasurement("ms/cm");
   ec.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_PH
@@ -114,6 +125,7 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
 #endif
 #ifdef HAVE_MOISTURE
   moisture.setDeviceClass("moisture");
+  moisture.setUnitOfMeasurement("%");
   moisture.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 }

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -115,7 +115,9 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
   co2.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif
 #ifdef HAVE_EC
-  ec.setDeviceClass("ec");
+  // As of 2025-Mar-28, Home Assistant does not have a device class for EC, we create a custom one
+  ec.setIcon("mdi:waveform");
+  ec.setName("Electrical Conductivity");
   ec.setUnitOfMeasurement("ms/cm");
   ec.setExpireAfter(EXPIRE_AFTER_SECONDS);
 #endif

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -24,25 +24,26 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
   light("light"),
 #endif
 #if defined(HAVE_DHT22) || defined(HAVE_AHT20)
-  temperature("temperature"), humidity("humidity"),
+  temperature("temperature", HASensorNumber::PrecisionP2),
+  humidity("humidity", HASensorNumber::PrecisionP2),
 #endif
 #ifdef HAVE_ENS160
   aqi("aqi"), tvoc("tvoc"), eco2("eco2"),
 #endif
 #ifdef HAVE_FLOW
-  flow("flow"),
+  flow("flow", HASensorNumber::PrecisionP2),
 #endif
 #ifdef HAVE_TEMP_WET
-  liquidtemp("liquidtemp"),
+  liquidtemp("liquidtemp", HASensorNumber::PrecisionP2),
 #endif
 #ifdef HAVE_CO2
   co2("co2"),
 #endif
 #ifdef HAVE_EC
-  ec("ec"),
+  ec("ec", HASensorNumber::PrecisionP2),
 #endif
 #ifdef HAVE_PH
-  ph("ph"),
+  ph("ph", HASensorNumber::PrecisionP2),
 #endif
 #ifdef HAVE_MOISTURE
   moisture("moisture"),

--- a/src/HomeAssistant.h
+++ b/src/HomeAssistant.h
@@ -8,6 +8,10 @@
 #include <ArduinoHA.h>
 #include "sensors.h"
 
+/**
+ * This class is a wrapper for the Home Assistant logic.
+ * It is where all the Home Assistant related code is located.
+ */
 class FuFarmHomeAssistant
 {
 public:
@@ -40,6 +44,7 @@ public:
 
   /**
    * Sets parameters of the MQTT connection using the IP address and port.
+   * Also sets device_class, units, expiry, and other properties of each sensor.
    * Connection to the broker will be done in the first loop cycle.
    * This class automatically reconnects to the broker if connection is lost.
    *
@@ -49,6 +54,7 @@ public:
 
   /**
    * Sets parameters of the MQTT connection using the IP address and port.
+   * Also sets device_class, units, expiry, and other properties of each sensor.
    * Connection to the broker will be done in the first loop cycle.
    * This class automatically reconnects to the broker if connection is lost.
    *

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -7,6 +7,10 @@
 
 #include <WiFi.h>
 
+/**
+ * This class is a wrapper for the WiFi logic.
+ * It is where all the WiFi related code is located.
+ */
 class WiFiManager
 {
 public:
@@ -22,7 +26,7 @@ public:
   ~WiFiManager();
 
   /**
-   * Scan for networks and connect to the one known
+   * Scan for networks and connect to the one configured.
    */
   void begin();
 

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -266,12 +266,12 @@ void FuFarmSensors::read(FuFarmSensorsData *dest)
   dest->waterLevelState = readWaterLevelState();
 }
 
+#ifdef HAVE_FLOW
 void FuFarmSensors::sen0217Interrupt()
 {
-#ifdef HAVE_FLOW
   pulseCount += 1;
-#endif
 }
+#endif
 
 bool FuFarmSensors::readWaterLevelState()
 {

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -61,21 +61,58 @@ struct FuFarmSensorsData
   } airQuality;
 };
 
+/**
+ * This class is a wrapper for the sensors logic.
+ * It is where all the sensors related code is located.
+ */
 class FuFarmSensors
 {
 public:
+  /**
+   * Creates a new instance of the FuFarmSensors class.
+   * Please note that only one instance of the class can be initialized at the same time.
+   */
   FuFarmSensors();
+
+  /**
+   * Cleanup resources created and managed by the FuFarmSensors class.
+   */
   ~FuFarmSensors();
-  void begin();                                           // initialization
-  void calibration(unsigned long readIntervalMs = 1000U); // calibration, should be called in a loop, ideally a config mode
-  void read(FuFarmSensorsData *dest);                     // read all sensor data
-  void sen0217Interrupt();                                // should be called from the interrupt handler passed in the constructor
+
+  /**
+   * Initializes the sensors.
+   * This should be called once at the beginning of the program.
+   * The required interrupts are also attached.
+   */
+  void begin();
+
+  /**
+   * Performs calibration of the sensors.
+   * Sensors that require calibration are EC, pH.
+   * This should be called in a loop, ideally in a config mode.
+   */
+  void calibration(unsigned long readIntervalMs = 1000U);
+
+  /**
+   * Reads all sensor data and stores it in the provided FuFarmSensorsData structure.
+   */
+  void read(FuFarmSensorsData *dest);
 
   /**
    * Returns existing instance (singleton) of the FuFarmSensors class.
    * It may be a null pointer if the FuFarmSensors object was never constructed or it was destroyed.
    */
   inline static FuFarmSensors *instance() { return _instance; }
+
+#ifdef HAVE_FLOW
+
+  /**
+   * Interrupt handler for the flow sensor.
+   * This should only be called from the interrupt handler.
+   */
+  void sen0217Interrupt();
+#endif
+
 
 private:
 #ifdef HAVE_DHT22

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -32,6 +32,7 @@
 
 struct FuFarmSensorsData
 {
+  // light intensity (lux)
   int32_t light;
 
   // relative humidity (%)

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -33,17 +33,31 @@
 struct FuFarmSensorsData
 {
   int32_t light;
+
+  // relative humidity (%)
   float humidity;
+
+  // measured in L/min
   float flow;
+
+  // measured in ppm
   int32_t co2;
   struct FuFarmSensorsTemperature
   {
+    // measured in °C
     float air;
+
+    // measured in °C
     float wet;
   } temperature;
+
+  // measured in ms/cm
   float ec;
   float ph;
+
+  // percentage (%) of water in a substance
   int32_t moisture;
+
   bool waterLevelState;
   struct FuFarmSensorsAirQuality
   {


### PR DESCRIPTION
A couple of error logs are showing up in HomeAssistant about missing data or misconfiguration. This is easiest to find when running in docker.

Changes:
- Set units for each sensor where known/possible. This is mandatory when using a device class and useful for the dashboard.
- `ec` is not a known device class. Instead, we setup the basics for EC (name, icon, units) which is more like a custom device class.
- Some sensors need better icons or name to disambiguate them or for specificity. These have been set where necessary and can be improved with time. Example: air & wet temperature values.
- Set precision for sensors for display purposes. 

Also, updated docs/comments for the custom classes we have.

Notes:
- When using the `illuminance` device class, the value should be in `lx` but the sensor we are using is not explicitly about offering the values in lx but just a value in the voltage range. Though this has been set to remove the error, a `TODO` was been added for reference later.