### PR TITLE
Set missing permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ on:
       - .github/**
       - '!.github/workflows/ci.yml'
 
+permissions:
+  contents: read
+
 env:
   CI: 1 # Needed for PlatformIO? https://docs.platformio.org/en/stable/envvars.html#envvar-CI
 


### PR DESCRIPTION
This fixes https://github.com/farm-urban/fufarm_arduino_sensors/security/code-scanning/1