### PR TITLE
Bump ArduinoJson from 6.21.3 to 7.3.1 and fix deprecation

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -82,7 +82,7 @@ framework = arduino
 board = leonardo
 lib_deps = 
 	${common.lib_deps}
-	bblanchon/ArduinoJson@6.21.3
+	bblanchon/ArduinoJson@7.3.1
 lib_deps_ignore = 
 	dawidchyrzynski/home-assistant-integration
 build_flags = 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ WiFiClient wifiClient;
 #endif
 FuFarmHomeAssistant ha(wifiClient);
 #else
-StaticJsonDocument<200> doc;
+JsonDocument doc;
 #endif
 
 void setup()


### PR DESCRIPTION
Alternative to #47 but changes from `StaticJsonDocument<200> doc` to `JsonDocument` as per https://arduinojson.org/news/2024/01/03/arduinojson-7/

> Could not edit existing PR without permissions to push to the branch