### PR TITLE
Reboot if WiFi connection is not obtained in 15 seconds

### DIFF
--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -2,6 +2,8 @@
 
 #if HAVE_WIFI
 
+#include "reboot.h"
+
 #ifdef ARDUINO_ESP32S3_DEV
 #include "esp_eap_client.h"
 #endif
@@ -194,8 +196,15 @@ void WiFiManager::connect()
   status = WiFi.begin(WIFI_SSID);
 #endif
 
+  unsigned long started = millis();
   while (status != WL_CONNECTED)
   {
+    // Timeout reached – perform a reset
+    if ((millis() - started) > WIFI_CONNECTION_REBOOT_TIMEOUT_MILLIS) {
+      Serial.println(" taken too long. Rebooting ....");
+      reboot();
+    }
+
     delay(500);
     Serial.print(".");
     status = WiFi.status();

--- a/src/config.h
+++ b/src/config.h
@@ -4,6 +4,9 @@
 // // Uncomment to skip WiFi connection for testing sensors
 // #define HAVE_WIFI 0
 
+// The amount of time to wait for a WiFi connection before rebooting
+#define WIFI_CONNECTION_REBOOT_TIMEOUT_MILLIS 15000 // 15 seconds
+
 #ifdef SENSORS_LIGHT_PIN
   #define HAVE_LIGHT
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,3 +159,8 @@ void loop()
   // Updating of sensor values happens over a longer delay by checking elapsed time above.
   delay(500);
 }
+
+void beforeReset()
+{
+  // TODO: save configuration and/or state so that we can resume after reboot (will be useful with auto dosing)
+}

--- a/src/reboot.c
+++ b/src/reboot.c
@@ -1,0 +1,34 @@
+#include "reboot.h"
+#include <Arduino.h>
+
+#if defined(ARDUINO_ARCH_ESP32)
+#include <esp_system.h>
+#elif defined(ARDUINO_UNOR4_WIFI)
+#else
+#include <avr/wdt.h>
+#endif
+
+void reboot()
+{
+  beforeReset();  // do housekeeping before rebooting
+
+#if defined(ARDUINO_ARCH_ESP32)
+  // For ESP32: restart the CPU
+  esp_restart();
+#elif defined(ARDUINO_UNOR4_WIFI)
+  // For the Uno R4 WiFi: perform a system reset using the NVIC
+  NVIC_SystemReset();
+#else
+  // For AVR boards like the Uno WiFi Rev2: enable watchdog with a short timeout
+  wdt_enable(WDTO_15MS);
+  while (true)
+  {
+    // Wait for the watchdog to reset the board
+  }
+#endif
+}
+
+__attribute__((weak)) void beforeReset() {
+  // Default empty implementation.
+  // Can be overridden elsewhere to save data to EEPROM or flash.
+}

--- a/src/reboot.h
+++ b/src/reboot.h
@@ -1,0 +1,19 @@
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * Function to be called before we initiate reboot.
+     * By default, this is a weak function hook so that it can be overridden in another file.
+     */
+    extern void beforeReset();
+
+    /**
+     * Reboot because WiFi connection has failed.
+     */
+    extern void reboot();
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This should resolve issues where WiFi connections fail. Rebooting is the best alternative compared to resetting as we expect everything to be reset on reboot unlike the latter where we may miss to reset other components.

Also added weak function hook to allow saving of any data before reboot no matter where it may have been called from. This could be configuration, state, or logged data that we may have later such as in #42.

To test this, attempt to connect to an unknown WiFi network.

Fixes: #49