### PR TITLE
Allow more ESP32 targets

### DIFF
--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -4,7 +4,7 @@
 
 #include "reboot.h"
 
-#ifdef ARDUINO_ESP32S3_DEV
+#ifdef ARDUINO_ARCH_ESP32
 #include "esp_eap_client.h"
 #endif
 
@@ -18,7 +18,7 @@ WiFiManager::~WiFiManager()
 
 void WiFiManager::begin()
 {
-#ifndef ARDUINO_ESP32S3_DEV
+#ifndef ARDUINO_ARCH_ESP32
   // check if the WiFi module is present
   if (WiFi.status() == WL_NO_MODULE)
   {
@@ -35,7 +35,7 @@ void WiFiManager::begin()
   }
 #endif
 
-#ifdef ARDUINO_ESP32S3_DEV
+#ifdef ARDUINO_ARCH_ESP32
   // Set WiFi to station mode and disconnect from an AP if it was previously connected.
   WiFi.mode(WIFI_STA);
 #endif
@@ -51,7 +51,7 @@ void WiFiManager::maintain()
   connect();
 }
 
-#ifndef ARDUINO_ESP32S3_DEV
+#ifndef ARDUINO_ARCH_ESP32
 void WiFiManager::printMacAddress(uint8_t mac[])
 {
   for (int i = 5; i >= 0; i--)
@@ -69,7 +69,7 @@ void WiFiManager::printMacAddress(uint8_t mac[])
 }
 #endif
 
-#ifdef ARDUINO_ESP32S3_DEV
+#ifdef ARDUINO_ARCH_ESP32
 const __FlashStringHelper *encryptionTypeToString(wifi_auth_mode_t mode)
 {
   switch (mode)
@@ -146,7 +146,7 @@ void WiFiManager::listNetworks()
   Serial.println();
 
   // Delete the scan result to free memory for code below.
-#ifdef ARDUINO_ESP32S3_DEV
+#ifdef ARDUINO_ARCH_ESP32
   WiFi.scanDelete();
 #endif
 }
@@ -169,7 +169,7 @@ void WiFiManager::connect()
   Serial.print("Attempting to connect to WiFi SSID: ");
   Serial.println(WIFI_SSID);
 
-#ifdef ARDUINO_ESP32S3_DEV
+#ifdef ARDUINO_ARCH_ESP32
 #if defined(WIFI_ENTERPRISE_IDENTITY)
   esp_eap_client_set_identity((uint8_t *)WIFI_ENTERPRISE_IDENTITY, strlen(WIFI_ENTERPRISE_IDENTITY));
 #endif
@@ -184,7 +184,7 @@ void WiFiManager::connect()
 #endif
 #endif
 
-#if defined(WIFI_ENTERPRISE_PASSWORD) && !defined(ARDUINO_ESP32S3_DEV)
+#if defined(WIFI_ENTERPRISE_PASSWORD) && !defined(ARDUINO_ARCH_ESP32)
   status = WiFi.beginEnterprise(WIFI_SSID,
                                 WIFI_ENTERPRISE_USERNAME,
                                 WIFI_ENTERPRISE_PASSWORD,
@@ -216,7 +216,7 @@ void WiFiManager::connect()
   Serial.print("SSID: ");
   Serial.println(WiFi.SSID());
 
-#ifdef ARDUINO_ESP32S3_DEV
+#ifdef ARDUINO_ARCH_ESP32
   Serial.print("BSSID: ");
   Serial.println(WiFi.BSSIDstr());
 #else
@@ -234,7 +234,7 @@ void WiFiManager::connect()
   Serial.print("IP Address: ");
   Serial.println(WiFi.localIP());
 
-#ifdef ARDUINO_ESP32S3_DEV
+#ifdef ARDUINO_ARCH_ESP32
   Serial.print("MAC address: ");
   Serial.println(WiFi.macAddress());
 #else

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -40,7 +40,7 @@ private:
   uint8_t _status;
 
 private:
-#ifndef ARDUINO_ESP32S3_DEV
+#ifndef ARDUINO_ARCH_ESP32
   void printMacAddress(uint8_t mac[]);
 #endif
   void listNetworks();

--- a/src/config.h
+++ b/src/config.h
@@ -37,7 +37,7 @@
   // For this flow sensor, only interrupt pins should be used. Configured on a rising edge
   // https://reference.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/
 
-  #if defined(ARDUINO_ESP32S3_DEV) // all pins
+  #if defined(ARDUINO_ARCH_ESP32) // all pins
   #elif defined(ARDUINO_AVR_LEONARDO) // only 0, 1, 2, 3, 7
     #if SENSORS_SEN0217_PIN == 0
     #elif SENSORS_SEN0217_PIN == 1
@@ -96,7 +96,7 @@
 
 // WiFi
 #ifndef HAVE_WIFI
-#if defined(ARDUINO_ESP32S3_DEV) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_AVR_UNO_WIFI_REV2)
+#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_AVR_UNO_WIFI_REV2)
   #define HAVE_WIFI 1
 #else
   #define HAVE_WIFI 0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ static boolean calibrationMode = false;
 #if HAVE_WIFI
 WiFiManager wifiManager;
 #if HOME_ASSISTANT_MQTT_TLS
-#ifdef ARDUINO_ESP32S3_DEV
+#ifdef ARDUINO_ARCH_ESP32
 #include <WiFiClientSecure.h>
 WiFiClientSecure wifiClient;
 #else
@@ -35,7 +35,7 @@ void setup()
   Serial.begin(9600);
 
   // https://www.arduino.cc/reference/en/language/functions/analog-io/analogreference/
-#if defined(ARDUINO_ESP32S3_DEV)
+#if defined(ARDUINO_ARCH_ESP32)
   // no need to set the reference voltage on ESP32-S3 because it offers reads in millivolts
   analogReadResolution(12); // change to 12-bit resolution
 #elif defined(ARDUINO_AVR_LEONARDO)
@@ -77,7 +77,7 @@ void setup()
 
 #if HAVE_WIFI
   wifiManager.begin();
-#if HOME_ASSISTANT_MQTT_TLS && defined(ARDUINO_ESP32S3_DEV)
+#if HOME_ASSISTANT_MQTT_TLS && defined(ARDUINO_ARCH_ESP32)
   wifiClient.setCACert(root_ca_certs);
 #endif
 

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -4,7 +4,7 @@
 
 // Will be different depending on the reference voltage.
 // We use float to avoid integer overflow.
-#if defined(ARDUINO_ESP32S3_DEV)
+#if defined(ARDUINO_ARCH_ESP32)
 // nothing to set there because it supports reading in millivolts
 #elif defined(ARDUINO_UNOR4_WIFI)
 #define ANALOG_REFERENCE_MILLI_VOLTS 5000.0f
@@ -15,7 +15,7 @@
 #endif
 
 // to avoid possible loss of precision, multiply before dividing
-#if defined(ARDUINO_ESP32S3_DEV)
+#if defined(ARDUINO_ARCH_ESP32)
 #define ANALOG_READ_MILLI_VOLTS(pin) (analogReadMilliVolts(pin))
 #else
 #define ANALOG_READ_MILLI_VOLTS(pin) ((analogRead(pin) * ANALOG_REFERENCE_MILLI_VOLTS) / ANALOG_MAX_VALUE)


### PR DESCRIPTION
Replace `ARDUINO_ESP32S3_DEV` with `ARDUINO_ARCH_ESP32` to allow more ESP32 board variants