### PR TITLE
Add noreturn attribute to reboot

### DIFF
--- a/src/reboot.c
+++ b/src/reboot.c
@@ -8,7 +8,7 @@
 #include <avr/wdt.h>
 #endif
 
-void reboot()
+__attribute__((noreturn)) void reboot()
 {
   beforeReset();  // do housekeeping before rebooting
 


### PR DESCRIPTION
Using the `noreturn` attribute communicates to the compiler and other developers that the function will not return control to the caller. This provides several benefits:

- Enables compiler optimizations and removes unnecessary post-call code.
- Prevents false-positive warnings for unreachable code.
- Improves code clarity and maintainability by making function intent explicit.
- Avoids relying on C++11 `[[noreturn]]`, which may not be consistently supported across all target platforms.

### Notes

- The attribute is supported across all boards/platforms used in this project
- The attribute has no effect on runtime behavior.
- Functions already include a `while(true)` or reset call to trap the system; this just formalizes the intent to the compiler.

No changes to external behavior or APIs — purely a compiler-level enhancement.