### PR TITLE
Changes to make sure reboot works and to work with flaky aht20 sensors

### DIFF
--- a/src/reboot.c
+++ b/src/reboot.c
@@ -20,7 +20,9 @@ __attribute__((noreturn)) void reboot()
   NVIC_SystemReset();
 #else
   // For AVR boards like the Uno WiFi Rev2: enable watchdog with a short timeout
-  wdt_enable(WDTO_15MS);
+  CPU_CCP = 0xD8;
+  WDT.CTRLA = 0x4;
+  wdt_enable(WDTO_2S);
   while (true)
   {
     // Wait for the watchdog to reset the board

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -165,6 +165,7 @@ private:
   int32_t readMoisture();
   float readTempWet();
   bool readWaterLevelState();
+  void initialiseAHT20();
 
 private:
   char buffer[10];


### PR DESCRIPTION
The Arduinos at our manchester site weren't rebooting when they couldn't connect to the wifi so I've added some code that seems to get the reboot to work successfully (not sure if was setting the variables or changing the watchdog timer, but together it seems to work).

Also, I'm having a lot of trouble with our AHT20 sensors, so this is an attempt to be a bit more robust in getting them recognised.