### PR TITLE
Add CODEOWNERS file to assign default reviewers for all changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS file for GitHub repository
+# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Why this is needed:
+# - Enables automated review requests (e.g., for Dependabot PRs)
+# - Helps maintain quality by ensuring that one of us reviews any PR
+
+# This line assigns the users as owners of all files, either one can review (not both)
+* @linucks @mburumaxwell


### PR DESCRIPTION
This commit introduces a CODEOWNERS file to assign the default reviewers for all files in the repository.

### Why:
- Ensures that all pull requests (including from Dependabot) are reviewed by one of the two core contributors.
- Aligns with GitHub's updated behavior as of April 2025, where the `reviewers` configuration for Dependabot is deprecated in favor of CODEOWNERS: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
- Helps enforce a shared responsibility model and better code quality through mandatory peer review.

Comments have been included in the CODEOWNERS file for clarity and maintainability.