### PR TITLE
Add ATmega4809 watchdog reboot and unify platform reset logic

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,8 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "platformio.platformio-ide",
-        "DavidAnson.vscode-markdownlint"
+        "DavidAnson.vscode-markdownlint",
+        "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [
         "ms-vscode.cpptools-extension-pack"

--- a/src/reboot.c
+++ b/src/reboot.c
@@ -18,13 +18,18 @@ __attribute__((noreturn)) void reboot()
 #elif defined(ARDUINO_UNOR4_WIFI)
   // For the Uno R4 WiFi: perform a system reset using the NVIC
   NVIC_SystemReset();
+#elif defined(ARDUINO_ARCH_MEGAAVR)
+  // ATmega4809 (e.g., Uno WiFi Rev2) WDT reset using direct register access
+  // From the section 11.5 – Configuration Change Protection (CCP).
+  // Unlocks protected writes for the next 4 CPU cycles.
+  // CCP must be set before WDT because setting WDT re-engages protection.
+  CPU_CCP = 0xD8; // D8 is a magic value not combination of individual flags
+  WDT.CTRLA = WDT_PERIOD_64CLK_gc; // Set timeout and enable watchdog
+  while (true) { }
 #else
-  // For AVR boards like the Uno WiFi Rev2: enable watchdog with a short timeout
+  // Classic AVR (e.g., Leonardo)
   wdt_enable(WDTO_15MS);
-  while (true)
-  {
-    // Wait for the watchdog to reset the board
-  }
+  while (true) { } // Wait for the watchdog to reset the board
 #endif
 }
 


### PR DESCRIPTION
This commit implements a direct watchdog-based reboot sequence for the ATmega4809 by unlocking protected registers with `CPU_CCP = 0xD8` and configuring `WDT.CTRLA = WDT_PERIOD_64CLK_gc` to trigger a reset after 64 cycles.

`wdt_enable(...)` is retained for classic AVR boards.

Detailed comments explain the CCP unlock window and register ordering.