### PR TITLE
Refactor Serial output to use F() macro for flash memory optimization

### DIFF
--- a/src/WiFiManager.cpp
+++ b/src/WiFiManager.cpp
@@ -22,7 +22,7 @@ void WiFiManager::begin()
   // check if the WiFi module is present
   if (WiFi.status() == WL_NO_MODULE)
   {
-    Serial.println("Communication with WiFi module failed!");
+    Serial.println(F("Communication with WiFi module failed!"));
     while (true)
       ; // don't continue
   }
@@ -31,7 +31,7 @@ void WiFiManager::begin()
   String fv = WiFi.firmwareVersion();
   if (fv < WIFI_FIRMWARE_LATEST_VERSION)
   {
-    Serial.println("Please upgrade the firmware");
+    Serial.println(F("Please upgrade the firmware"));
   }
 #endif
 
@@ -63,7 +63,7 @@ void WiFiManager::printMacAddress(uint8_t mac[])
     Serial.print(mac[i], HEX);
     if (i > 0)
     {
-      Serial.print(":");
+      Serial.print(F(":"));
     }
   }
 }
@@ -121,25 +121,25 @@ const __FlashStringHelper *encryptionTypeToString(uint8_t type)
 
 void WiFiManager::listNetworks()
 {
-  Serial.println("** Scan Networks **");
+  Serial.println(F("** Scan Networks **"));
   int8_t count = WiFi.scanNetworks();
   if (count == -1)
   {
-    Serial.println("Couldn't scan for WiFi networks");
+    Serial.println(F("Couldn't scan for WiFi networks"));
     return; // nothing more to do here
   }
 
-  Serial.print("Number of available networks: ");
+  Serial.print(F("Number of available networks: "));
   Serial.println(count);
   for (int8_t i = 0; i < count; i++)
   {
     Serial.print(i);
-    Serial.print(") ");
+    Serial.print(F(") "));
     Serial.print(WiFi.SSID(i));
-    Serial.print("\tSignal: ");
+    Serial.print(F("\tSignal: "));
     Serial.print(WiFi.RSSI(i));
-    Serial.print(" dBm");
-    Serial.print("\tEncryption: ");
+    Serial.print(F(" dBm"));
+    Serial.print(F("\tEncryption: "));
     Serial.print(encryptionTypeToString(WiFi.encryptionType(i)));
     Serial.println();
   }
@@ -163,10 +163,10 @@ void WiFiManager::connect()
   // detect disconnection
   if (_status == WL_CONNECTED && _status != status)
   {
-    Serial.println("WiFi disconnected");
+    Serial.println(F("WiFi disconnected"));
   }
 
-  Serial.print("Attempting to connect to WiFi SSID: ");
+  Serial.print(F("Attempting to connect to WiFi SSID: "));
   Serial.println(WIFI_SSID);
 
 #ifdef ARDUINO_ARCH_ESP32
@@ -201,45 +201,45 @@ void WiFiManager::connect()
   {
     // Timeout reached – perform a reset
     if ((millis() - started) > WIFI_CONNECTION_REBOOT_TIMEOUT_MILLIS) {
-      Serial.println(" taken too long. Rebooting ....");
+      Serial.println(F(" taken too long. Rebooting ...."));
       reboot();
     }
 
     delay(500);
-    Serial.print(".");
+    Serial.print(F("."));
     status = WiFi.status();
   }
   _status = WL_CONNECTED;
 
   Serial.println();
-  Serial.println("WiFi connected successfully!");
-  Serial.print("SSID: ");
+  Serial.println(F("WiFi connected successfully!"));
+  Serial.print(F("SSID: "));
   Serial.println(WiFi.SSID());
 
 #ifdef ARDUINO_ARCH_ESP32
-  Serial.print("BSSID: ");
+  Serial.print(F("BSSID: "));
   Serial.println(WiFi.BSSIDstr());
 #else
   uint8_t mac[WL_MAC_ADDR_LENGTH];
   WiFi.BSSID(mac);
-  Serial.print("BSSID: ");
+  Serial.print(F("BSSID: "));
   printMacAddress(mac);
   Serial.println();
 #endif
 
-  Serial.print("Signal strength (RSSI): ");
+  Serial.print(F("Signal strength (RSSI): "));
   Serial.print(WiFi.RSSI());
-  Serial.println(" dBm");
+  Serial.println(F(" dBm"));
 
-  Serial.print("IP Address: ");
+  Serial.print(F("IP Address: "));
   Serial.println(WiFi.localIP());
 
 #ifdef ARDUINO_ARCH_ESP32
-  Serial.print("MAC address: ");
+  Serial.print(F("MAC address: "));
   Serial.println(WiFi.macAddress());
 #else
   WiFi.macAddress(mac);
-  Serial.print("MAC address: ");
+  Serial.print(F("MAC address: "));
   printMacAddress(mac);
   Serial.println();
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,7 @@ void setup()
   uint8_t mac[6];
   WiFi.macAddress(mac);
   ha.setUniqueDeviceId(mac, sizeof(mac));
-  Serial.print("Home Assistant Unique Device ID: ");
+  Serial.print(F("Home Assistant Unique Device ID: "));
   Serial.println(ha.getUniqueId());
   ha.begin();
 

--- a/src/sensors.cpp
+++ b/src/sensors.cpp
@@ -55,12 +55,12 @@ void FuFarmSensors::initialiseAHT20()
   uint8_t status = -1, count = 0;
   while ((status = aht20.begin()) != 0)
   {
-    Serial.print("AHT20 sensor initialisation failed. Error status: ");
+    Serial.print(F("AHT20 sensor initialisation failed. Error status: "));
     Serial.println(status);
     count++;
     if (count > 10)
     {
-      Serial.println("Could not initialise AHT20 sensor - continuing without it");
+      Serial.println(F("Could not initialise AHT20 sensor - continuing without it"));
       break;
     }
     delay(1000);
@@ -89,12 +89,12 @@ void FuFarmSensors::begin()
   count = 0;
   while ((status = ens160.begin()) != NO_ERR)
   {
-    Serial.print("ENS160 sensor initialisation failed. Error status: ");
+    Serial.print(F("ENS160 sensor initialisation failed. Error status: "));
     Serial.println(status);
     count++;
     if (count > 5)
     {
-      Serial.println("Could not initialise ENS160 sensor - continuing without it");
+      Serial.println(F("Could not initialise ENS160 sensor - continuing without it"));
       break;
     }
     delay(1000);
@@ -222,7 +222,7 @@ void FuFarmSensors::read(FuFarmSensorsData *dest)
   }
   else
   {
-    Serial.println("AHT20 sensor not ready - resetting");
+    Serial.println(F("AHT20 sensor not ready - resetting"));
     airTemperature = dest->temperature.air = -1;
     dest->humidity = -1;
     aht20.reset();
@@ -240,13 +240,13 @@ void FuFarmSensors::read(FuFarmSensorsData *dest)
   }
   else
   {
-    Serial.println("Could not set air temperature and humidity for ENS160. Its values might not be accurate.");
+    Serial.println(F("Could not set air temperature and humidity for ENS160. Its values might not be accurate."));
   }
 
   uint8_t status = ens160.getENS160Status();
   if (status != DFRobot_ENS160::eSensorStatus_t::eNormalOperation)
   {
-    Serial.print("ENS160 is not yet in normal operation mode (initial phase can take upto 1 hour). Current mode: ");
+    Serial.print(F("ENS160 is not yet in normal operation mode (initial phase can take upto 1 hour). Current mode: "));
     Serial.println(status);
   }
   else
@@ -387,13 +387,13 @@ float FuFarmSensors::readTempWet()
 
   if (OneWire::crc8(addr, 7) != addr[7])
   {
-    // Serial.println("CRC is not valid!");
+    // Serial.println(F("CRC is not valid!"));
     return -1001;
   }
 
   if (addr[0] != 0x10 && addr[0] != 0x28)
   {
-    // Serial.print("Device is not recognized");
+    // Serial.print(F("Device is not recognized"));
     return -1002;
   }
 


### PR DESCRIPTION
Update `Serial.print()` and `Serial.println()` calls to use the `F()` macro where applicable to store constant strings in flash memory instead of SRAM. This reduces SRAM usage and helps prevent memory overflow issues. It too much flash memory is used, we shall catch it at compile time, reducing possibility of runtime crash from the same reasons.