### PR TITLE
Add channel to listing WiFi networks and option to skip listing networks

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,6 +67,8 @@ build_flags_wifi =
 	; -DWIFI_ENTERPRISE_PASSWORD=\"<your-value>\"
 	; -DWIFI_ENTERPRISE_IDENTITY=\"<your-value>\"
 	; -DWIFI_ENTERPRISE_CA=\"<your-value>\"
+	; by default, we list all networks but if you want to skip this, uncomment the line below
+	; -DWIFI_SKIP_LIST_NETWORKS=1
 extra_scripts = 
 	pre:scripts/version.py
 

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -43,7 +43,9 @@ private:
 #ifndef ARDUINO_ARCH_ESP32
   void printMacAddress(uint8_t mac[]);
 #endif
+#if !WIFI_SKIP_LIST_NETWORKS
   void listNetworks();
+#endif
   void connect();
 };
 


### PR DESCRIPTION
By default, we scan and list all available WiFi networks on every boot, but that can be slow and eats into precious SRAM. In situations where the network parameters are already stable and known, it makes sense to bypass the scan entirely.

Furthermore, in dense environments, such as mesh networks with multiple APs broadcasting the same SSID but on different channels, repeated SSID entries at different RSSI values clutter the results and add little value.

This change adds a new `WIFI_SKIP_LIST_NETWORKS` macro to skip the network scan when desired, and it also includes the channel number in the scan results to disambiguate them.

The WiFi scan results are no better tabulated now for easier reading (Oh my! This is so hard in C). In the tabulation, SSIDs are truncated/padded at 32 characters because that is the most common max length.