### PR TITLE
Disconnect MQTT on destructor and do not update values when disconnected

### DIFF
--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -141,6 +141,7 @@ FuFarmHomeAssistant::FuFarmHomeAssistant(Client &client) :
 
 FuFarmHomeAssistant::~FuFarmHomeAssistant()
 {
+  mqtt.disconnect();
 }
 
 void FuFarmHomeAssistant::setUniqueDeviceId(const uint8_t *value, uint8_t length)
@@ -166,8 +167,14 @@ void FuFarmHomeAssistant::maintain()
   mqtt.loop();
 }
 
-void FuFarmHomeAssistant::setValues(FuFarmSensorsData *source, const bool force)
+void FuFarmHomeAssistant::update(FuFarmSensorsData *source, const bool force)
 {
+  if (!connected())
+  {
+    Serial.println(F("MQTT not connected, skipping update"));
+    return;
+  }
+
 #ifdef HAVE_WATER_LEVEL_STATE
   waterLevel.setState(source->waterLevelState, force);
 #endif

--- a/src/HomeAssistant.h
+++ b/src/HomeAssistant.h
@@ -73,14 +73,20 @@ public:
 
   /**
    * Publishes MQTT messages for configured sensors.
+   * If the connection has not been established, nothing is published.
    * In some cases, if a sensor value is the same as the previous one the MQTT message won't be published.
-   * It means that MQTT messages will produced each time the setValues method is called but they might not
-   * be the same from time to time.
+   * This means MQTT messages are not always produced when the update method is called.
    *
    * @param source All values for configured sensors.
    * @param force Forces to update the state without comparing it to a previous known state.
    */
-  void setValues(FuFarmSensorsData *source, const bool force = true);
+  void update(FuFarmSensorsData *source, const bool force = true);
+
+  /**
+   * Returns the current state of the MQTT connection.
+   * @return true if connected, false otherwise.
+   */
+  inline bool connected() { return mqtt.isConnected(); }
 
 private:
   HADevice device;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,7 +106,7 @@ void loop()
     timepoint = millis();
     sensors.read(&sensorsData);
 #if HAVE_WIFI
-    ha.setValues(&sensorsData);
+    ha.update(&sensorsData);
 #else
     // populate json
 #if defined(HAVE_DHT22) || defined(HAVE_AHT20)


### PR DESCRIPTION
- No longer publish sensor information if MQTT is not connected. This also removes confusion when looking at logs.
- Disconnect MQTT to Home Assistant on destructor
- Rename `setValues(...)` to `update(...)`