### PR TITLE
Enable mDNS-based discovery of Home Assistant for MQTT

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -22,7 +22,7 @@ Sometimes, you may not have direct access to a Home Assistant setup and you want
 
    `mosquitto -v -c mosquitto.conf`
 
-### Ngrok to resolve connection issues
+### Ngrok to troubleshoot internet connection issues
 
 <details>
 <summary><strong>Details</strong></summary>

--- a/README.md
+++ b/README.md
@@ -155,3 +155,19 @@ There are several steps to get this working:
 ```bash
 mqtt: !include mqtt.yml
 ```
+
+## Service Discovery
+
+By default, the IP for the home assistant installation is discovered using mDNS/Bonjour but you can fix by setting the value next to `build_flags_ha_host` in [platformio.ini](./platformio.ini). Using discovery is the recommended approach to avoid hard coded values and to update should the IP change. Discovery happens at boot and every 5 min.
+
+To aid with trouble shooting, the device broadcasts a TCP service for port 7005 but the port cannot actually be opened. To check discovery from your computer or the PI using the following commands.
+
+|OS|Task|Command|
+|--|--|--|
+|macOS|List all services|`dns-sd -B _services._dns-sd._tcp local`|
+|macOS|List just fufarm ones|`dns-sd -B _fufarm`|
+|macOS|List just home-assistant ones|`dns-sd -B _home-assistant`|
+|macOS|Get details for one|`dns-sd -L "Farm Urban <mac>`|
+|Linux|List all services|`avahi-browse -at`|
+|Linux|List just fufarm ones with details|`avahi-browse -rt _fufarm._tcp`|
+|Linux|List just home-assistant ones with details|`avahi-browse -rt _home-assistant._tcp`|

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,11 +11,12 @@
 [common]
 lib_deps = 
 	beegee-tokyo/DHT sensor library for ESPx@1.19.0
-	https://github.com/PaulStoffregen/OneWire.git@2.3.8
+	https://github.com/arduino-libraries/ArduinoMDNS.git#875d963
 	https://github.com/DFRobot/DFRobot_AHT20.git@1.0.0
 	https://github.com/DFRobot/DFRobot_EC.git#ed56349
 	https://github.com/DFRobot/DFRobot_ENS160.git#7a45a70
 	https://github.com/DFRobot/DFRobot_PH.git#43f229a
+	https://github.com/PaulStoffregen/OneWire.git@2.3.8
 	knolleary/PubSubClient@2.8
 	dawidchyrzynski/home-assistant-integration@2.1.0
 build_flags = 
@@ -32,12 +33,14 @@ build_flags_sensors =
 	-DSENSORS_DS18S20_PIN=4
 	-DSENSORS_SEN0204_PIN=5
 	-DHAVE_AHT20=1
-	-DHAVE_ENS160=1
+	; -DHAVE_ENS160=1
 	-DCALIBRATION_TOGGLE_PIN=12
+build_flags_ha_host = \"192.168.8.100\"
 build_flags_ha = 
+	; By default mDNS/Bonjour is used to discover IP, works in most cases, uncomment the line below to disable it and fix a value above
+	; -DHOME_ASSISTANT_MQTT_HOST=${common.build_flags_ha_host}
 	; Debugging for HA is enabled for easier visibility into what is happening in the library
 	-DARDUINOHA_DEBUG
-	-DHOME_ASSISTANT_MQTT_HOST=\"192.168.8.100\"
 	-DHOME_ASSISTANT_MQTT_PORT=1883
 	-DHOME_ASSISTANT_MQTT_TLS=0
 	-DHOME_ASSISTANT_MQTT_TLS_SUPPRESS_WARNING=0
@@ -69,6 +72,10 @@ build_flags_wifi =
 	; -DWIFI_ENTERPRISE_CA=\"<your-value>\"
 	; by default, we list all networks but if you want to skip this, uncomment the line below
 	; -DWIFI_SKIP_LIST_NETWORKS=1
+build_flags_esp32 = 
+	; These allow use of the USB/JTAG port which has less noise or funny characters
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
 extra_scripts = 
 	pre:scripts/version.py
 
@@ -92,6 +99,7 @@ build_flags =
 	${common.build_flags_sensors}
 	${common.build_flags_wifi}
 	${common.build_flags_ha}
+	${common.build_flags_esp32}
 extra_scripts = ${common.extra_scripts}
 
 [env:leonardo]
@@ -132,8 +140,10 @@ build_flags =
 	${common.build_flags_sensors}
 	${common.build_flags_wifi}
 	${common.build_flags_ha}
+	; this exists for builds to work because we have ran out of flash space
+	-DHOME_ASSISTANT_MQTT_HOST=${common.build_flags_ha_host}
 
-; The ci_validation_x configs exist to test that code works with only one sensor.
+; The ci_validation_[1,2] configs exist to test that code works with only one sensor.
 ; Two environments to test that one works without the other.
 [env:ci_validation_1]
 extends = env:leonardo
@@ -142,6 +152,21 @@ build_flags = ${common.build_flags} -DSENSORS_LIGHT_PIN=A0
 [env:ci_validation_2]
 extends = env:leonardo
 build_flags = ${common.build_flags} -DHAVE_AHT20=1
+
+; The ci_validation_3 config exist to test that discovery works for uno wifi rev2
+[env:ci_validation_3]
+extends = env:uno_wifi_rev2
+build_flags = 
+	${env:uno_wifi_rev2.build_flags}
+	-USENSORS_CO2_PIN
+	-USENSORS_EC_PIN
+	-USENSORS_PH_PIN
+	-USENSORS_MOISTURE_PIN
+	-USENSORS_SEN0217_PIN
+	-USENSORS_DS18S20_PIN
+	-USENSORS_SEN0204_PIN
+	-UCALIBRATION_TOGGLE_PIN
+	-UHOME_ASSISTANT_MQTT_HOST
 
 ; To be restored once we actually create tests
 ; [env:native]

--- a/src/HomeAssistant.cpp
+++ b/src/HomeAssistant.cpp
@@ -149,17 +149,26 @@ void FuFarmHomeAssistant::setUniqueDeviceId(const uint8_t *value, uint8_t length
   device.setUniqueId(value, length);
 }
 
-void FuFarmHomeAssistant::begin()
+void FuFarmHomeAssistant::connect(const NetworkEndpoint *endpoint)
 {
-  begin(HOME_ASSISTANT_MQTT_HOST,
-        HOME_ASSISTANT_MQTT_PORT,
-        HOME_ASSISTANT_MQTT_USERNAME,
-        HOME_ASSISTANT_MQTT_PASSWORD);
-}
+  // if already connected, disconnect (assumes this method is only called when the endpoint is acquired or has changed)
+  if (connected()) {
+    mqtt.disconnect();
+  }
 
-void FuFarmHomeAssistant::begin(const char *host, const uint16_t port, const char *username, const char *password)
-{
-  mqtt.begin(host, port, username, password);
+  const char *username = HOME_ASSISTANT_MQTT_USERNAME;
+  const char *password = HOME_ASSISTANT_MQTT_PASSWORD;
+
+  if (endpoint->type == NetworkEndpointType::DNS) {
+    mqtt.begin(endpoint->hostname, endpoint->port, username, password);
+  }
+  else if (endpoint->type == NetworkEndpointType::IP) {
+    mqtt.begin(endpoint->ip, endpoint->port, username, password);
+  }
+  else {
+    Serial.print("Unknown or unhandled network endpoint type: ");
+    Serial.println(endpoint->type);
+  }
 }
 
 void FuFarmHomeAssistant::maintain()

--- a/src/HomeAssistant.h
+++ b/src/HomeAssistant.h
@@ -6,6 +6,7 @@
 #if USE_HOME_ASSISTANT
 
 #include <ArduinoHA.h>
+#include "ServiceDiscovery.h"
 #include "sensors.h"
 
 /**
@@ -48,22 +49,11 @@ public:
    * Connection to the broker will be done in the first loop cycle.
    * This class automatically reconnects to the broker if connection is lost.
    *
-   * Connection parameters (host, port, username, password, etc) are pulled from the build flags.
-   */
-  void begin();
-
-  /**
-   * Sets parameters of the MQTT connection using the IP address and port.
-   * Also sets device_class, units, expiry, and other properties of each sensor.
-   * Connection to the broker will be done in the first loop cycle.
-   * This class automatically reconnects to the broker if connection is lost.
+   * Authentication parameters (username, password) are pulled from the build flags.
    *
-   * @param host Domain or IP address of the MQTT broker.
-   * @param port Port of the MQTT broker.
-   * @param username Username for authentication. It can be nullptr if the anonymous connection needs to be performed.
-   * @param password Password for authentication. It can be nullptr if the anonymous connection needs to be performed.
+   * @param endpoint Endpoint of the MQTT broker containing Domain or IP address and Port.
    */
-  void begin(const char *host, const uint16_t port = 1883, const char *username = nullptr, const char *password = nullptr);
+  void connect(const NetworkEndpoint *endpoint);
 
   /**
    * This method should be called periodically inside the main loop of the firmware.

--- a/src/ServiceDiscovery.cpp
+++ b/src/ServiceDiscovery.cpp
@@ -1,0 +1,137 @@
+#include "ServiceDiscovery.h"
+
+#if NETWORK_SERVICE_DISCOVERY
+
+#include "reboot.h"
+
+#define HOME_ASSISTANT_SERVICE_NAME "_home-assistant"
+
+ServiceDiscovery* ServiceDiscovery::_instance = nullptr;
+
+static void serviceFoundCallback(const char* type, MDNSServiceProtocol_t protocol, const char* name, IPAddress address, uint16_t port, const char* txt)
+{
+  ServiceDiscovery::instance()->serviceFound(type, protocol, name, address, port, txt);
+}
+
+ServiceDiscovery::ServiceDiscovery(UDP& udpClient) : mdns(udpClient)
+{
+  _instance = this;
+}
+
+ServiceDiscovery::~ServiceDiscovery()
+{
+  _instance = nullptr;
+}
+
+void ServiceDiscovery::begin(IPAddress ip, const char* hostname, uint8_t* mac)
+{
+  if (!mdns.begin(ip, hostname)) {
+    Serial.println("Error setting up MDNS!");
+    reboot();
+  }
+
+  // We register a service to aid with checking if the device is on the network. This aids troubleshooting
+  // service discovery where network has different conditions like mDNS/Bonjour disabled, different VLAN.
+  // The name must start with the description as per examples.
+  // Without the TXT record, sometimes execution crashes; see https://github.com/arduino-libraries/ArduinoMDNS/issues/36
+  //                                                          https://github.com/arduino-libraries/ArduinoMDNS/pull/23
+  // The TXT record "\x05id=01" implies TXT record with 5 bytes 'id=01' which is just a random key value pair
+  // Post 7005 is random, not using 80 to avoid confusion with HTTP.
+  // The service name includes the mac address to make it easier to identify multiple devices.
+  // You can list this on Linux using "avahi-browse -at" and just for this one "avahi-browse -rt _fufarm._tcp"
+  // On mac "dns-sd -B _services._dns-sd._tcp local" will list all services, "dns-sd -B _fufarm" will list just the ones for farm urban,
+  // and "dns-sd -L "Farm Urban <mac>" _fufarm" will print the TXT for the particular device.
+  char serviceName[11 + 12 + 8 + 1]; // sizeof("Farm Urban ") = 10; sizeof(mac*2) = 12; sizeof("._fufarm") = 8; + EOF (1) = 32
+  snprintf(serviceName, sizeof(serviceName), "Farm Urban %02X%02X%02X%02X%02X%02X._fufarm", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  mdns.addServiceRecord(serviceName, 7005, MDNSServiceProtocol_t::MDNSServiceTCP, "\x05id=01");
+
+  // set callback for when service is found
+  mdns.setServiceFoundCallback(serviceFoundCallback);
+
+  discover(true);
+}
+
+void ServiceDiscovery::maintain()
+{
+  // only if the discovery is not already in progress
+  if (!mdns.isDiscoveringService()) {
+    // check if the time since the last discovery is greater than 5 min
+    const auto elapsedTime = millis() - discoverTimepoint;
+    if (elapsedTime > (5 * 60 * 1000))
+    {
+      discover(false);
+      discoverTimepoint = millis(); // reset the timepoint (must be done after discovery)
+    }
+  }
+
+  mdns.run();
+}
+
+void ServiceDiscovery::discover(bool initial)
+{
+#if USE_HOME_ASSISTANT
+  // The mosquitto add-on does not advertise itself so we search for Home Assistant instead
+  // On macOS, you can run "dns-sd -B _services._dns-sd._udp local" to see available services
+  if (initial) {
+    Serial.println(F("Searching for " HOME_ASSISTANT_SERVICE_NAME "._tcp.local service ... "));
+  }
+  if (!mdns.startDiscoveringService(HOME_ASSISTANT_SERVICE_NAME, _MDNSServiceProtocol_t::MDNSServiceTCP, 5000)) {
+    Serial.println("Error starting mDNS discovery!");
+  }
+#endif // USE_HOME_ASSISTANT
+}
+
+void ServiceDiscovery::serviceFound(const char* type,
+                                    MDNSServiceProtocol_t protocol,
+                                    const char* name,
+                                    IPAddress address,
+                                    uint16_t port,
+                                    const char* txt)
+{
+#if USE_HOME_ASSISTANT
+  if (name == NULL) {
+    // if the endpoint type is still unknown set it to defaults
+    if (_haEndpoint.type == NetworkEndpointType::UNKNOWN) {
+      Serial.println(F("No Home Assistant service found. Ensure you are on the same network."));
+      Serial.println(F("Custom network configurations such as through Tailscale may affect discovery."));
+    }
+
+    return;
+  }
+
+  bool initial = _haEndpoint.type != NetworkEndpointType::IP;
+  bool changed = _haEndpoint.type != NetworkEndpointType::IP
+              || _haEndpoint.ip != address
+              || _haEndpoint.port != HOME_ASSISTANT_MQTT_PORT;
+  // We use the known port for MQTT because home assistant is on a different port (usually 8123)
+  updateNetworkEndpoint(&_haEndpoint, &address, NULL, HOME_ASSISTANT_MQTT_PORT );
+
+  if (changed) {
+    Serial.print(initial ? F("Found Home Assistant service at ") : F("Found updated Home Assistant service at "));
+    Serial.print(_haEndpoint.ip);
+    Serial.print(F(":"));
+    Serial.println(port); // Serial.println(_haEndpoint.port);
+
+    if (haEndpointUpdatedCallback) {
+      haEndpointUpdatedCallback(&_haEndpoint);
+    }
+  }
+#endif // USE_HOME_ASSISTANT
+}
+
+void ServiceDiscovery::updateNetworkEndpoint(NetworkEndpoint *endpoint, IPAddress* ip, const char *hostname, uint16_t port)
+{
+  if (ip != NULL) {
+    endpoint->ip = *ip;
+    endpoint->type = NetworkEndpointType::IP;
+  }
+
+  if (hostname != NULL) {
+    endpoint->hostname = hostname;
+    endpoint->type = NetworkEndpointType::DNS;
+  }
+
+  endpoint->port = port;
+}
+
+#endif // NETWORK_SERVICE_DISCOVERY

--- a/src/ServiceDiscovery.h
+++ b/src/ServiceDiscovery.h
@@ -1,0 +1,110 @@
+#include "config.h"
+
+#ifndef SERVICE_DISCOVERY_H
+#define SERVICE_DISCOVERY_H
+
+#if HAVE_NETWORK
+
+#include <Arduino.h>
+
+enum NetworkEndpointType
+{
+    UNKNOWN,
+    IP,
+    DNS,
+};
+
+struct NetworkEndpoint
+{
+    NetworkEndpointType type;
+    IPAddress ip;
+    const char *hostname;
+    uint16_t port;
+};
+
+#endif
+
+#if NETWORK_SERVICE_DISCOVERY
+
+#include <ArduinoMDNS.h>
+
+/**
+ * This class is a wrapper for the service discovery via mDNS/Bonjour.
+ */
+class ServiceDiscovery
+{
+public:
+  /**
+   * Creates a new instance of the ServiceDiscovery class.
+   * Please note that only one instance of the class can be initialized at the same time.
+   */
+  ServiceDiscovery(UDP& udpClient);
+
+  /**
+   * Cleanup resources created and managed by the ServiceDiscovery class.
+   */
+  ~ServiceDiscovery();
+
+  /**
+   * Scan for networks and connect to the one configured.
+   *
+   * @param ip IP address of the network interface (WiFi, Ethernet, etc).
+   * @param hostname Hostname set on the network interface.
+   * @param mac MAC address of the network interface.
+   */
+  void begin(IPAddress ip, const char* hostname, uint8_t* mac);
+
+  /**
+   * This method should be called periodically inside the main loop of the firmware.
+   * It's safe to call this method in some interval (like 5ms).
+   */
+  void maintain();
+
+#if USE_HOME_ASSISTANT
+  /**
+   * Returns the network endpoint to use for home assistant
+   */
+  inline NetworkEndpoint* haEndpoint() { return &_haEndpoint; }
+
+  /**
+   * Registers callback that will be called each time the ha endpoint is updated.
+   *
+   * @param callback
+   */
+  inline void onHaEndpointUpdated(void (*callback)(NetworkEndpoint *endpoint)) { haEndpointUpdatedCallback = callback; }
+#endif
+
+  /**
+   * Returns existing instance (singleton) of the ServiceDiscovery class.
+   * It may be a null pointer if the ServiceDiscovery object was never constructed or it was destroyed.
+   */
+  inline static ServiceDiscovery *instance() { return _instance; }
+
+  void serviceFound(const char* type,
+                    MDNSServiceProtocol_t protocol,
+                    const char* name,
+                    IPAddress address,
+                    uint16_t port,
+                    const char* txt);
+
+private:
+    MDNS mdns;
+#if USE_HOME_ASSISTANT
+  NetworkEndpoint _haEndpoint;
+#endif
+
+private:
+  void (*haEndpointUpdatedCallback)(NetworkEndpoint *endpoint);
+  unsigned long discoverTimepoint;
+
+  /// Living instance of the ServiceDiscovery class. It can be nullptr.
+  static ServiceDiscovery *_instance;
+
+private:
+  void discover(bool initial);
+  void updateNetworkEndpoint(NetworkEndpoint *endpoint, IPAddress* ip, const char *hostname, uint16_t port);
+};
+
+#endif // NETWORK_SERVICE_DISCOVERY
+
+#endif // SERVICE_DISCOVERY_H

--- a/src/WiFiManager.h
+++ b/src/WiFiManager.h
@@ -36,17 +36,32 @@ public:
    */
   void maintain();
 
-private:
-  uint8_t _status;
+  /**
+   * Get the station interface IP address.
+   */
+  inline IPAddress localIP() { return WiFi.localIP(); }
+
+  /**
+   * Get the station interface IP address.
+   */
+  inline uint8_t * macAddress() { return _macAddress; }
+
+  /**
+   * Get the station interface IP address.
+   */
+  inline const char* hostname() { return _hostname; }
 
 private:
-#ifndef ARDUINO_ARCH_ESP32
-  void printMacAddress(uint8_t mac[]);
-#endif
+  uint8_t _status;
+  char _hostname[20]; // e.g. "fufarm-012345678901" plus EOF
+  uint8_t _macAddress[MAC_ADDRESS_LENGTH];
+
+private:
+void printMacAddress(uint8_t mac[]);
 #if !WIFI_SKIP_LIST_NETWORKS
   void listNetworks();
 #endif
-  void connect();
+  void connect(bool initial);
 };
 
 #endif // HAVE_WIFI

--- a/src/config.h
+++ b/src/config.h
@@ -121,8 +121,26 @@
   #endif
 #endif
 
+// General Network
+#if HAVE_WIFI // || HAVE_ETHERNET || HAVE_CELLULAR
+  #define HAVE_NETWORK 1
+#else
+  #define HAVE_NETWORK 0
+#endif
+
+#if HAVE_NETWORK
+  #define MAC_ADDRESS_LENGTH 6
+#endif
+
+// Network Service Discovery (mDNS/Bonjour)
+#if HAVE_NETWORK && !defined(HOME_ASSISTANT_MQTT_HOST)
+  #define NETWORK_SERVICE_DISCOVERY 1
+#else
+  #define NETWORK_SERVICE_DISCOVERY 0
+#endif
+
 // Home Assistant
-#if HAVE_WIFI
+#if HAVE_NETWORK
   #define USE_HOME_ASSISTANT 1
 #else
   #define USE_HOME_ASSISTANT 0


### PR DESCRIPTION
This change introduces mDNS-based service discovery for Home Assistant on ESP32, ensuring that the device can automatically locate the MQTT broker without relying on a hardcoded IP or hostname. By querying for the `_home-assistant._tcp.local` service, the device no longer needs manual configuration when the Raspberry Pi’s IP changes or is renamed. Instead, it uses the mDNS responder to find the Home Assistant instance on the local network and connect to MQTT on the known port.

Home Assistant’s Mosquitto add-on does not advertise its own `_mqtt._tcp` service, but Supervisor-based installations always publish `_home-assistant._tcp`. We leverage that broadcast to discover Home Assistant’s hostname. Because the HTTP port (8123) is advertised, the code explicitly overrides the port with `HOME_ASSISTANT_MQTT_PORT` (typically 1883).

Notes:
- To account for modern networks, the IPv6 address is prioritised when available.
- The device broadcasts a service `_fufarm._tcp.local` that can be used to troubleshoot visibility.
- When `HOME_ASSISTANT_MQTT_HOST` is specified, discovery is not done.
- Should the server change IP (happens in congested networks), changed are picked up every 5 min when rescan happens.
- The `uno_wifi_rev2` board can no longer support these additional features except if some other sensors are removed. This is done in CI to ensure it build with discovery.

If a user wants to verify what mDNS records are available, the following commands can be used
|OS|Task|Command|
|--|--|--|
|macOS|List all services|`dns-sd -B _services._dns-sd._tcp local`|
|macOS|List just fufarm ones|`dns-sd -B _fufarm`|
|macOS|List just home-assistant ones|`dns-sd -B _home-assistant`|
|macOS|Get details for one|`dns-sd -L "Farm Urban <mac>`|
|Linux|List all services|`avahi-browse -at`|
|Linux|List just fufarm ones with details|`avahi-browse -rt _fufarm._tcp`|
|Linux|List just home-assistant ones with details|`avahi-browse -rt _home-assistant._tcp`|