### PR TITLE
Reduce MQTT keepalive interval to improve disconnection detection and recovery

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -161,8 +161,8 @@
   // PUBACK is only sent in response to PUBLISH when QoS=1. With the library in use, it is similar to fire-and-forget.
   // If the keep alive value is larger than the sample duration (SAMPLE_WINDOW_MILLIS), we never end up sending the PING packets.
   // Consequently, we never get to detect server disconnection.
-  // If we have a lower value here, PING packets are sent every now and them meaning we can detect disconnects sooner.
-  // It would be a good idea to calculate the value by halfing the sample duration (SAMPLE_WINDOW_MILLIS) but it may result is too much noise.
+  // If we have a lower value here, PING packets are sent every now and then meaning we can detect disconnects sooner.
+  // It would be a good idea to calculate the value by halfing the sample duration (SAMPLE_WINDOW_MILLIS) but it may result in too much noise.
   #define HOME_ASSISTANT_MQTT_KEEPALIVE 30
 #endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -156,7 +156,14 @@
 #if USE_HOME_ASSISTANT
   #define HOME_ASSISTANT_DISCOVERY_PREFIX "homeassistant"
   #define HOME_ASSISTANT_DATA_PREFIX "homeassistant"
-  #define HOME_ASSISTANT_MQTT_KEEPALIVE 90
+
+  // The HomeAssistant library uses PubSubClient which does not support Publishing with QoS=1 but supports subscribe with QoS=1.
+  // PUBACK is only sent in response to PUBLISH when QoS=1. With the library in use, it is similar to fire-and-forget.
+  // If the keep alive value is larger than the sample duration (SAMPLE_WINDOW_MILLIS), we never end up sending the PING packets.
+  // Consequently, we never get to detect server disconnection.
+  // If we have a lower value here, PING packets are sent every now and them meaning we can detect disconnects sooner.
+  // It would be a good idea to calculate the value by halfing the sample duration (SAMPLE_WINDOW_MILLIS) but it may result is too much noise.
+  #define HOME_ASSISTANT_MQTT_KEEPALIVE 30
 #endif
 
 #if HOME_ASSISTANT_MQTT_TLS


### PR DESCRIPTION
Previously, when the MQTT broker (i.e., Home Assistant) went down and came back up, the device failed to reconnect. This was because the MQTT disconnection was not detected (WiFi remained connected), and the default MQTT keepalive interval (90s) was longer than the publish interval (60s), so a PING was never sent.

`PubSubClient` only supports QoS 0 for publishing, meaning no `PUBACK` is expected, and delivery failures can’t be detected. While the library supports `PINGREQ`/`PINGRESP` for keepalive, this mechanism was ineffective because messages were published frequently enough to reset the keepalive timer (`lastOutActivity`), yet not frequently enough to detect broken connections.

This change reduces the MQTT keepalive interval to 30 seconds (shorter than the default publish interval) ensuring that if no data is sent, a `PINGREQ` will be sent and a `PINGRESP` expected. This allows the client to detect a broken connection and trigger reconnection logic.

This is a pragmatic fix given the limitations of PubSubClient.

More explanation: https://github.com/farm-urban/fufarm_arduino_sensors/issues/73#issuecomment-2958212353

Fixes: #73