### PR TITLE
Add support for `dfrobot_firebeetle2_esp32e`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Create firmware folder
         run: |
           mkdir -p firmware
+          cp ${{ github.workspace }}/.pio/build/dfrobot_firebeetle2_esp32e/firmware.elf ${{ github.workspace }}/firmware/dfrobot_firebeetle2_esp32e.elf
+          cp ${{ github.workspace }}/.pio/build/dfrobot_firebeetle2_esp32e/firmware.bin ${{ github.workspace }}/firmware/dfrobot_firebeetle2_esp32e.bin
           cp ${{ github.workspace }}/.pio/build/esp32-s3-devkitc1-n16r8/firmware.elf ${{ github.workspace }}/firmware/esp32-s3-devkitc1-n16r8.elf
           cp ${{ github.workspace }}/.pio/build/esp32-s3-devkitc1-n16r8/firmware.bin ${{ github.workspace }}/firmware/esp32-s3-devkitc1-n16r8.bin
           cp ${{ github.workspace }}/.pio/build/leonardo/firmware.elf ${{ github.workspace }}/firmware/leonardo.elf

--- a/platformio.ini
+++ b/platformio.ini
@@ -71,8 +71,9 @@ build_flags_wifi =
 	; -DWIFI_ENTERPRISE_CA=\"<your-value>\"
 	; by default, we list all networks but if you want to skip this, uncomment the line below
 	; -DWIFI_SKIP_LIST_NETWORKS=1
-build_flags_esp32 = 
-	; These allow use of the USB/JTAG port which has less noise or funny characters
+build_flags_esp32_usb_2_ports = 
+	; For boards with two ports, these allow use of the USB/JTAG port which has less noise
+	; or funny characters but may need special/official drivers for it.
 	-DARDUINO_USB_MODE=1
 	-DARDUINO_USB_CDC_ON_BOOT=1
 extra_scripts = 
@@ -87,6 +88,7 @@ extra_scripts =
 ; default_envs = uno_r4_wifi
 ; default_envs = uno_wifi_rev2
 default_envs = 
+	dfrobot_firebeetle2_esp32e
 	esp32-s3-devkitc1-n16r8
 	leonardo
 	uno_r4_wifi
@@ -94,6 +96,18 @@ default_envs =
 	ci_validation_1
 	ci_validation_2
 	ci_validation_3
+
+[env:dfrobot_firebeetle2_esp32e]
+platform = https://github.com/pioarduino/platform-espressif32.git#54.03.20
+framework = arduino
+board = dfrobot_firebeetle2_esp32e
+lib_deps = ${common.lib_deps}
+build_flags = 
+	${common.build_flags}
+	${common.build_flags_sensors}
+	${common.build_flags_wifi}
+	${common.build_flags_ha}
+extra_scripts = ${common.extra_scripts}
 
 [env:esp32-s3-devkitc1-n16r8]
 platform = https://github.com/pioarduino/platform-espressif32.git#54.03.20
@@ -105,7 +119,7 @@ build_flags =
 	${common.build_flags_sensors}
 	${common.build_flags_wifi}
 	${common.build_flags_ha}
-	${common.build_flags_esp32}
+	${common.build_flags_esp32_usb_2_ports}
 extra_scripts = ${common.extra_scripts}
 
 [env:leonardo]


### PR DESCRIPTION
This is closest board with gravity shield support in the ESP32 ecosystem.

Board definition: https://github.com/pioarduino/platform-espressif32/blob/main/boards/dfrobot_firebeetle2_esp32e.json