### PR TITLE
Focus on ESP32 based boards only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,16 +69,10 @@ jobs:
       - name: Create firmware folder
         run: |
           mkdir -p firmware
-          cp ${{ github.workspace }}/.pio/build/dfrobot_firebeetle2_esp32e/firmware.elf ${{ github.workspace }}/firmware/dfrobot_firebeetle2_esp32e.elf
-          cp ${{ github.workspace }}/.pio/build/dfrobot_firebeetle2_esp32e/firmware.bin ${{ github.workspace }}/firmware/dfrobot_firebeetle2_esp32e.bin
-          cp ${{ github.workspace }}/.pio/build/esp32-s3-devkitc1-n16r8/firmware.elf ${{ github.workspace }}/firmware/esp32-s3-devkitc1-n16r8.elf
-          cp ${{ github.workspace }}/.pio/build/esp32-s3-devkitc1-n16r8/firmware.bin ${{ github.workspace }}/firmware/esp32-s3-devkitc1-n16r8.bin
-          cp ${{ github.workspace }}/.pio/build/leonardo/firmware.elf ${{ github.workspace }}/firmware/leonardo.elf
-          cp ${{ github.workspace }}/.pio/build/leonardo/firmware.hex ${{ github.workspace }}/firmware/leonardo.hex
-          cp ${{ github.workspace }}/.pio/build/uno_r4_wifi/firmware.elf ${{ github.workspace }}/firmware/uno_r4_wifi.elf
-          cp ${{ github.workspace }}/.pio/build/uno_r4_wifi/firmware.bin ${{ github.workspace }}/firmware/uno_r4_wifi.bin
-          cp ${{ github.workspace }}/.pio/build/uno_wifi_rev2/firmware.elf ${{ github.workspace }}/firmware/uno_wifi_rev2.elf
-          cp ${{ github.workspace }}/.pio/build/uno_wifi_rev2/firmware.hex ${{ github.workspace }}/firmware/uno_wifi_rev2.hex
+          cp ${{ github.workspace }}/.pio/build/esp32e_firebeetle2/firmware.elf ${{ github.workspace }}/firmware/esp32e_firebeetle2.elf
+          cp ${{ github.workspace }}/.pio/build/esp32e_firebeetle2/firmware.bin ${{ github.workspace }}/firmware/esp32e_firebeetle2.bin
+          cp ${{ github.workspace }}/.pio/build/esp32s3_devkitc/firmware.elf ${{ github.workspace }}/firmware/esp32s3_devkitc.elf
+          cp ${{ github.workspace }}/.pio/build/esp32s3_devkitc/firmware.bin ${{ github.workspace }}/firmware/esp32s3_devkitc.bin
 
       - name: Upload Artifact (firmware)
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,13 +52,13 @@ By participating in this project, you agree to abide by our Code of Conduct. Ple
 2. Build for a specific board:
 
    ```bash
-   pio run --environment uno_wifi_rev2
+   pio run --environment esp32e_firebeetle2
    ```
 
 3. Upload to a board:
 
    ```bash
-   pio run --environment uno_wifi_rev2 --target upload
+   pio run --environment esp32e_firebeetle2 --target upload
    ```
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -18,11 +18,8 @@ A comprehensive sensor management system for Arduino-based environmental monitor
 
 The system is tested and supported on the following boards:
 
-- [Arduino Leonardo](https://store.arduino.cc/products/arduino-leonardo-with-headers) - Basic sensor support
-- [Arduino UNO R4 WiFi](https://store.arduino.cc/products/uno-r4-wifi) - WiFi-enabled, direct Home Assistant integration
-- [Arduino UNO WiFi R2](https://store.arduino.cc/products/arduino-uno-wifi-rev2) - WiFi-enabled, direct Home Assistant integration
-- [ESP32 S3 DevKitC 1 N16R8](https://www.amazon.co.uk/ESP32-DevKitC-WROOM1-Development-Bluetooth/dp/B0CLD4QKT1) - Advanced features, WiFi-enabled
-- [DFROBOT FireBeetle](https://wiki.dfrobot.com/FireBeetle_Board_ESP32_E_SKU_DFR0654) - Requires CH34x USB driver (see below)
+- [FireBeetle ESP32 E](https://wiki.dfrobot.com/FireBeetle_Board_ESP32_E_SKU_DFR0654) - Requires CH34x USB driver (see below)
+- [ESP32 S3 DevKitC 1](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/index.html) - Advanced features
 
 > [!NOTE]
 > While other boards supported by PlatformIO can be added, Arduino-compatible boards are recommended for easier integration.
@@ -78,8 +75,8 @@ sudo modprobe ch341
    pio run
 
    # For a specific board
-   pio run --environment uno_wifi_rev2
-   pio run --environment uno_wifi_rev2 --target upload
+   pio run --environment esp32e_firebeetle2
+   pio run --environment esp32e_firebeetle2 --target upload
    ```
 
 Common commands:
@@ -87,11 +84,11 @@ Common commands:
 | Action                  | Command Format                                        | Example                                               |
 | ----------------------- | ----------------------------------------------------- | ----------------------------------------------------- |
 | Build (default boards)  |                                                       | `pio run`                                             |
-| Build (specific board)  | `pio run --environment {env-name}`                    | `pio run --environment uno_wifi_rev2`                 |
-| Upload (specific board) | `pio run --environment {env-name} --target upload`    | `pio run --environment uno_wifi_rev2 --target upload` |
+| Build (specific board)  | `pio run --environment {env-name}`                    | `pio run --environment esp32e_firebeetle2`                 |
+| Upload (specific board) | `pio run --environment {env-name} --target upload`    | `pio run --environment esp32e_firebeetle2 --target upload` |
 <!-- | Test                    |                                                       | `pio test --environment native`                       | -->
 | Clean (default boards)  |                                                       | `pio run --target fullclean`                          |
-| Clean (specific board)  | `pio run --environment {env-name} --target fullclean` | `pio run --environment leonardo --target fullclean`   |
+| Clean (specific board)  | `pio run --environment {env-name} --target fullclean` | `pio run --environment esp32e_firebeetle2 --target fullclean`   |
 
 ## WiFi Configuration
 
@@ -105,14 +102,6 @@ Boards that support WiFi are generally easier to work with because they transmit
 >
 > 1. Networks with captive portals do not work.
 > 2. Networks with spaces need to be escaped appropriately. For example, to connect to a network named `ASK4 Wireless`, you should use `-DWIFI_SSID=\"ASK4\ Wireless\"`. To connect to a network named `Jen's iPhone`, you should use `-DWIFI_SSID=\"Jen\'s\ iPhone\"`. At times, the device is unable to connect when there are special characters, renaming your phone should fix it, e.g `Jen's iphone` -> `JensiPhone`.
-> 3. Arduino UNO R4 WiFi, does not (yet) support enterprise WiFi.
-
-### WiFi Firmware
-
-The WiFi modules may need firmware updates to work properly such as when using an older board or you have not used a particular board for a while. In some cases, multiple attempts may be required. See:
-
-- [Arduino UNO R4 WiFi](https://support.arduino.cc/hc/en-us/articles/9670986058780-Update-the-connectivity-module-firmware-on-UNO-R4-WiFi)
-- [Arduino UNO WiFi Rev2](https://github.com/xcape-io/ArduinoProps/blob/master/help/WifiNinaFirmware.md)
 
 ## Sensor Configuration
 
@@ -184,7 +173,7 @@ There are several steps to get this working:
    ln -s ~/.platformio/penv/bin/piodebuggdb ~/.local/bin/piodebuggdb
    ```
 
-3. Build and upload the code to the arduino with: `./upload.sh leonardo`
+3. Build and upload the code to the arduino with: `./upload.sh esp32e_firebeetle2`
 4. Create a python virtual environment to host mqtt-io:
 
    ```bash

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,7 @@ lib_deps =
 	https://github.com/DFRobot/DFRobot_ENS160.git#7a45a70
 	https://github.com/DFRobot/DFRobot_PH.git#43f229a
 	https://github.com/PaulStoffregen/OneWire.git@2.3.8
+	bblanchon/ArduinoJson@7.4.2
 	knolleary/PubSubClient@2.8
 	dawidchyrzynski/home-assistant-integration@2.1.0
 build_flags = 
@@ -71,7 +72,7 @@ build_flags_wifi =
 	; -DWIFI_ENTERPRISE_CA=\"<your-value>\"
 	; by default, we list all networks but if you want to skip this, uncomment the line below
 	; -DWIFI_SKIP_LIST_NETWORKS=1
-build_flags_esp32_usb_2_ports = 
+build_flags_usb_2_ports = 
 	; For boards with two ports, these allow use of the USB/JTAG port which has less noise
 	; or funny characters but may need special/official drivers for it.
 	-DARDUINO_USB_MODE=1
@@ -83,21 +84,15 @@ extra_scripts =
 ; a command override using --environment/-e options
 ; Comment/uncomment, one of the lines to target just one which is easier/faster for local use.
 [platformio]
-; default_envs = esp32-s3-devkitc1-n16r8
-; default_envs = leonardo
-; default_envs = uno_r4_wifi
-; default_envs = uno_wifi_rev2
+; default_envs = esp32s3_devkitc
+; default_envs = esp32e_firebeetle2
 default_envs = 
-	dfrobot_firebeetle2_esp32e
-	esp32-s3-devkitc1-n16r8
-	leonardo
-	uno_r4_wifi
-	uno_wifi_rev2
+	esp32e_firebeetle2
+	esp32s3_devkitc
 	ci_validation_1
 	ci_validation_2
-	ci_validation_3
 
-[env:dfrobot_firebeetle2_esp32e]
+[env:esp32e_firebeetle2]
 platform = https://github.com/pioarduino/platform-espressif32.git#54.03.20
 framework = arduino
 board = dfrobot_firebeetle2_esp32e
@@ -109,83 +104,36 @@ build_flags =
 	${common.build_flags_ha}
 extra_scripts = ${common.extra_scripts}
 
-[env:esp32-s3-devkitc1-n16r8]
+[env:esp32s3_devkitc]
 platform = https://github.com/pioarduino/platform-espressif32.git#54.03.20
 framework = arduino
-board = esp32-s3-devkitc1-n16r8
+board = esp32-s3-devkitc-1
 lib_deps = ${common.lib_deps}
 build_flags = 
 	${common.build_flags}
 	${common.build_flags_sensors}
 	${common.build_flags_wifi}
 	${common.build_flags_ha}
-	${common.build_flags_esp32_usb_2_ports}
+	${common.build_flags_usb_2_ports}
 extra_scripts = ${common.extra_scripts}
-
-[env:leonardo]
-platform = platformio/atmelavr@5.1.0
-framework = arduino
-board = leonardo
-lib_deps = 
-	${common.lib_deps}
-	bblanchon/ArduinoJson@7.4.2
-lib_ignore = dawidchyrzynski/home-assistant-integration
-build_flags = 
-	${common.build_flags}
-	${common.build_flags_sensors}
-
-[env:uno_r4_wifi]
-platform = platformio/renesas-ra@1.7.0
-framework = arduino
-board = uno_r4_wifi
-lib_deps = ${common.lib_deps}
-build_flags = 
-	${common.build_flags}
-	${common.build_flags_sensors}
-	${common.build_flags_wifi}
-	${common.build_flags_ha}
-; needed for WiFi sublibraries to be found correctly
-lib_ldf_mode = deep+
-
-[env:uno_wifi_rev2]
-platform = platformio/atmelmegaavr@1.9.0
-framework = arduino
-board = uno_wifi_rev2
-lib_deps = 
-	${common.lib_deps}
-	arduino-libraries/WiFiNINA@1.9.1
-build_flags = 
-	${common.build_flags}
-	${common.build_flags_sensors}
-	${common.build_flags_wifi}
-	${common.build_flags_ha}
-	; this exists for builds to work because we have ran out of flash space
-	-DHOME_ASSISTANT_MQTT_HOST=${common.build_flags_ha_host}
 
 ; The ci_validation_[1,2] configs exist to test that code works with only one sensor.
 ; Two environments to test that one works without the other.
 [env:ci_validation_1]
-extends = env:leonardo
-build_flags = ${common.build_flags} -DSENSORS_LIGHT_PIN=A0
+extends = env:esp32e_firebeetle2
+build_flags = 
+	${common.build_flags}
+	${common.build_flags_wifi}
+	${common.build_flags_ha}
+	-DSENSORS_LIGHT_PIN=A0
 
 [env:ci_validation_2]
-extends = env:leonardo
-build_flags = ${common.build_flags} -DHAVE_AHT20=1
-
-; The ci_validation_3 config exist to test that discovery works for uno wifi rev2
-[env:ci_validation_3]
-extends = env:uno_wifi_rev2
+extends = env:esp32e_firebeetle2
 build_flags = 
-	${env:uno_wifi_rev2.build_flags}
-	-USENSORS_CO2_PIN
-	-USENSORS_EC_PIN
-	-USENSORS_PH_PIN
-	-USENSORS_MOISTURE_PIN
-	-USENSORS_SEN0217_PIN
-	-USENSORS_DS18S20_PIN
-	-USENSORS_SEN0204_PIN
-	-UCALIBRATION_TOGGLE_PIN
-	-UHOME_ASSISTANT_MQTT_HOST
+	${common.build_flags}
+	${common.build_flags_wifi}
+	${common.build_flags_ha}
+	-DHAVE_AHT20=1
 
 ; To be restored once we actually create tests
 ; [env:native]

--- a/src/config.h
+++ b/src/config.h
@@ -33,31 +33,6 @@
 
 #ifdef SENSORS_SEN0217_PIN
   #define HAVE_FLOW
-
-  // For this flow sensor, only interrupt pins should be used. Configured on a rising edge
-  // https://reference.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/
-
-  #if defined(ARDUINO_ARCH_ESP32) // all pins
-  #elif defined(ARDUINO_AVR_LEONARDO) // only 0, 1, 2, 3, 7
-    #if SENSORS_SEN0217_PIN == 0
-    #elif SENSORS_SEN0217_PIN == 1
-    #elif SENSORS_SEN0217_PIN == 2
-    #elif SENSORS_SEN0217_PIN == 3
-    #elif SENSORS_SEN0217_PIN == 7
-    #else
-      #error "Pin configured for SEN0217 (flow sensor) must support interrupts on LEONARDO."
-    #endif
-  #elif defined(ARDUINO_UNOR4_WIFI) // all digital pins
-    #if SENSORS_SEN0217_PIN < 0 || SENSORS_SEN0217_PIN > 13
-      #error "Pin configured for SEN0217 (flow sensor) must support interrupts on UNO WIFI REV2."
-    #endif
-  #elif defined(ARDUINO_AVR_UNO_WIFI_REV2) // only 2 or 3
-    #if SENSORS_SEN0217_PIN != 2 && SENSORS_SEN0217_PIN != 3
-      #error "Pin configured for SEN0217 (flow sensor) must support interrupts on UNO R4 WIFI."
-    #endif
-  #else // any other board we have not validated
-    #pragma message "⚠️ Unable to validate if pin configured for SEN0217 (flow sensor) allows interrupts required."
-  #endif
 #endif
 
 #ifdef SENSORS_SEN0204_PIN
@@ -96,11 +71,8 @@
 
 // WiFi
 #ifndef HAVE_WIFI
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_AVR_UNO_WIFI_REV2)
   #define HAVE_WIFI 1
-#else
-  #define HAVE_WIFI 0
-#endif
+  // #define HAVE_WIFI 0
 #endif
 
 #if (defined(WIFI_ENTERPRISE_USERNAME) && !defined(WIFI_ENTERPRISE_PASSWORD)) || \
@@ -112,12 +84,6 @@
   #endif
   #ifndef WIFI_ENTERPRISE_CA
     #define WIFI_ENTERPRISE_CA "" // default in the library
-  #endif
-#endif
-
-#if defined(ARDUINO_UNOR4_WIFI)
-  #if defined(WIFI_ENTERPRISE_USERNAME) || defined(WIFI_ENTERPRISE_PASSWORD)
-    #error "Arduino Uno R4 WiFi does not yet support enterprise WiFi."
   #endif
 #endif
 
@@ -168,15 +134,6 @@
 
 #if HOME_ASSISTANT_MQTT_TLS
 extern const char root_ca_certs[];
-#endif
-
-#if HOME_ASSISTANT_MQTT_TLS && !HOME_ASSISTANT_MQTT_TLS_SUPPRESS_WARNING
-  #if defined(ARDUINO_UNOR4_WIFI)
-    #pragma message "⚠️ Arduino Uno R4 WiFi may not work with self signed certificates for TLS."
-  #endif
-  #if defined(ARDUINO_AVR_UNO_WIFI_REV2)
-    #pragma message "⚠️ Arduino Uno WiFi Rev2 may not work with self signed certificates for TLS."
-  #endif
 #endif
 
 #endif // CONFIG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,12 +20,8 @@ static boolean calibrationMode = false;
 #if HAVE_WIFI
 WiFiManager wifiManager;
 #if HOME_ASSISTANT_MQTT_TLS
-#ifdef ARDUINO_ARCH_ESP32
 #include <WiFiClientSecure.h>
 WiFiClientSecure tcpClient;
-#else
-WiFiSSLClient tcpClient;
-#endif
 #else
 WiFiClient tcpClient;
 #endif
@@ -47,19 +43,8 @@ void setup()
   Serial.begin(9600);
 
   // https://www.arduino.cc/reference/en/language/functions/analog-io/analogreference/
-#if defined(ARDUINO_ARCH_ESP32)
   // no need to set the reference voltage on ESP32-S3 because it offers reads in millivolts
   analogReadResolution(12); // change to 12-bit resolution
-#elif defined(ARDUINO_AVR_LEONARDO)
-  analogReference(DEFAULT); // Set the default voltage of the reference voltage
-#elif defined(ARDUINO_UNOR4_WIFI)
-  analogReference(AR_DEFAULT); // AR_DEFAULT: 5V on the Uno R4 WiFi
-  analogReadResolution(14);    // change to 14-bit resolution
-#elif defined(ARDUINO_AVR_UNO_WIFI_REV2)
-  analogReference(VDD); // VDD: Vdd of the ATmega4809. 5V on the Uno WiFi Rev2
-#else // any other board we have not validated
-#pragma message "⚠️ Unable to set analogue reference voltage. Board not supported."
-#endif
 
   sensors.begin();
 
@@ -89,7 +74,7 @@ void setup()
 
 #if HAVE_WIFI
   wifiManager.begin();
-#if HOME_ASSISTANT_MQTT_TLS && defined(ARDUINO_ARCH_ESP32)
+#if HOME_ASSISTANT_MQTT_TLS
   tcpClient.setCACert(root_ca_certs);
 #endif
 #endif // HAVE_WIFI

--- a/src/reboot.c
+++ b/src/reboot.c
@@ -1,36 +1,11 @@
-#include "reboot.h"
-#include <Arduino.h>
-
-#if defined(ARDUINO_ARCH_ESP32)
 #include <esp_system.h>
-#elif defined(ARDUINO_UNOR4_WIFI)
-#else
-#include <avr/wdt.h>
-#endif
+
+#include "reboot.h"
 
 __attribute__((noreturn)) void reboot()
 {
-  beforeReset();  // do housekeeping before rebooting
-
-#if defined(ARDUINO_ARCH_ESP32)
-  // For ESP32: restart the CPU
+  beforeReset(); // do housekeeping before rebooting
   esp_restart();
-#elif defined(ARDUINO_UNOR4_WIFI)
-  // For the Uno R4 WiFi: perform a system reset using the NVIC
-  NVIC_SystemReset();
-#elif defined(ARDUINO_ARCH_MEGAAVR)
-  // ATmega4809 (e.g., Uno WiFi Rev2) WDT reset using direct register access
-  // From the section 11.5 – Configuration Change Protection (CCP).
-  // Unlocks protected writes for the next 4 CPU cycles.
-  // CCP must be set before WDT because setting WDT re-engages protection.
-  CPU_CCP = 0xD8; // D8 is a magic value not combination of individual flags
-  WDT.CTRLA = WDT_PERIOD_64CLK_gc; // Set timeout and enable watchdog
-  while (true) { }
-#else
-  // Classic AVR (e.g., Leonardo)
-  wdt_enable(WDTO_15MS);
-  while (true) { } // Wait for the watchdog to reset the board
-#endif
 }
 
 __attribute__((weak)) void beforeReset() {

--- a/upload.sh
+++ b/upload.sh
@@ -1,22 +1,19 @@
 #!/bin/bash
 export PATH=/opt/platformio/bin:$PATH
 
-usage="Usage $0 leonardo|uno_r4_wifi|uno_wifi_rev2";
+usage="Usage $0 esp32e_firebeetle2|esp32s3_devkitc";
 
 if [ $# -ne 1 ]; then
     echo $usage
     exit 1;
 fi
 
-if [ $1 = "leonardo" ]
+if [ $1 = "esp32e_firebeetle2" ]
 then
-    board=leonardo
-elif [ $1 = "uno_r4_wifi" ]
+    board=esp32e_firebeetle2
+elif [ $1 = "esp32s3_devkitc" ]
 then
-    board=uno_r4_wifi
-elif [ $1 = "uno_wifi_rev2" ]
-then
-    board=uno_wifi_rev2
+    board=esp32s3_devkitc
 else
     echo $usage
     exit 1;


### PR DESCRIPTION
Removes support for boards that are not based on ESP32. As more features are added, the need to have the WiFi (co)processor reliable enough increases. Arduino is also increasingly using ESP32 based boards. This informed the decision to move focus to that.

Changes:
- Support for Arduino Uno WiFi R2, Arduino Leonardo and Arduino Uno R4 WiFi have been dropped.
- Significantly reduced pre-processor directives given the fewer archs.
- Environments have shorter names for easier typing and identification.
- Support for ESP32S3 while retained, has dropped to the base board to keep initial requirements at a minimum.