### PR TITLE
Refactor PlatformIO config: centralize flags, simplify environments

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,21 +8,19 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+; The environments specified in default_envs are used when the current command does not have
+; a command override using --environment/-e options
+; Comment/uncomment, one of the lines to target just one which is easier/faster for local use.
+[platformio]
+; default_envs = esp32s3_devkitc
+; default_envs = esp32e_firebeetle2
+default_envs = 
+	esp32e_firebeetle2
+	esp32s3_devkitc
+	ci_validation_1
+	ci_validation_2
+
 [common]
-lib_deps = 
-	beegee-tokyo/DHT sensor library for ESPx@1.19.0
-	https://github.com/arduino-libraries/ArduinoMDNS.git#875d963
-	https://github.com/DFRobot/DFRobot_AHT20.git@1.0.0
-	https://github.com/DFRobot/DFRobot_EC.git#ed56349
-	https://github.com/DFRobot/DFRobot_ENS160.git#7a45a70
-	https://github.com/DFRobot/DFRobot_PH.git#43f229a
-	https://github.com/PaulStoffregen/OneWire.git@2.3.8
-	bblanchon/ArduinoJson@7.4.2
-	knolleary/PubSubClient@2.8
-	dawidchyrzynski/home-assistant-integration@2.1.0
-build_flags = 
-	; sample time in milliseconds (60k = 60seconds or 1 minute)
-	-DSAMPLE_WINDOW_MILLIS=60000
 build_flags_sensors = 
 	-DSENSORS_LIGHT_PIN=A0
 	-DSENSORS_CO2_PIN=A1
@@ -37,7 +35,35 @@ build_flags_sensors =
 	; -DHAVE_ENS160=1
 	-DCALIBRATION_TOGGLE_PIN=12
 build_flags_ha_host = \"192.168.8.100\"
-build_flags_ha = 
+
+[env]
+platform = https://github.com/pioarduino/platform-espressif32.git#54.03.20
+framework = arduino
+lib_deps = 
+	beegee-tokyo/DHT sensor library for ESPx@1.19.0
+	https://github.com/arduino-libraries/ArduinoMDNS.git#875d963
+	https://github.com/DFRobot/DFRobot_AHT20.git@1.0.0
+	https://github.com/DFRobot/DFRobot_EC.git#ed56349
+	https://github.com/DFRobot/DFRobot_ENS160.git#7a45a70
+	https://github.com/DFRobot/DFRobot_PH.git#43f229a
+	https://github.com/PaulStoffregen/OneWire.git@2.3.8
+	bblanchon/ArduinoJson@7.4.2
+	knolleary/PubSubClient@2.8
+	dawidchyrzynski/home-assistant-integration@2.1.0
+build_flags = 
+	; sample time in milliseconds (60k = 60seconds or 1 minute)
+	-DSAMPLE_WINDOW_MILLIS=60000
+
+	-DWIFI_SSID=\"fumanc\"
+	; -DWIFI_PASSPHRASE=\"<your-value>\"
+	; in most cases you do not need enterprise wifi but if you do, maybe just the username and password
+	; -DWIFI_ENTERPRISE_USERNAME=\"johnson@gov.uk\"
+	; -DWIFI_ENTERPRISE_PASSWORD=\"<your-value>\"
+	; -DWIFI_ENTERPRISE_IDENTITY=\"<your-value>\"
+	; -DWIFI_ENTERPRISE_CA=\"<your-value>\"
+	; by default, we list all networks but if you want to skip this, uncomment the line below
+	; -DWIFI_SKIP_LIST_NETWORKS=1
+
 	; By default mDNS/Bonjour is used to discover IP, works in most cases, uncomment the line below to disable it and fix a value above
 	; -DHOME_ASSISTANT_MQTT_HOST=${common.build_flags_ha_host}
 	; Debugging for HA is enabled for easier visibility into what is happening in the library
@@ -62,77 +88,38 @@ build_flags_ha =
 	-DEX_ARDUINOHA_SCENE
 	-DEX_ARDUINOHA_SELECT
 	-DEX_ARDUINOHA_TAG_SCANNER
-build_flags_wifi = 
-	-DWIFI_SSID=\"fumanc\"
-	; -DWIFI_PASSPHRASE=\"<your-value>\"
-	; in most cases you do not need enterprise wifi but if you do, maybe just the username and password
-	; -DWIFI_ENTERPRISE_USERNAME=\"johnson@gov.uk\"
-	; -DWIFI_ENTERPRISE_PASSWORD=\"<your-value>\"
-	; -DWIFI_ENTERPRISE_IDENTITY=\"<your-value>\"
-	; -DWIFI_ENTERPRISE_CA=\"<your-value>\"
-	; by default, we list all networks but if you want to skip this, uncomment the line below
-	; -DWIFI_SKIP_LIST_NETWORKS=1
-build_flags_usb_2_ports = 
-	; For boards with two ports, these allow use of the USB/JTAG port which has less noise
-	; or funny characters but may need special/official drivers for it.
-	-DARDUINO_USB_MODE=1
-	-DARDUINO_USB_CDC_ON_BOOT=1
+
 extra_scripts = 
 	pre:scripts/version.py
 
-; The environments specified in default_envs are used when the current command does not have
-; a command override using --environment/-e options
-; Comment/uncomment, one of the lines to target just one which is easier/faster for local use.
-[platformio]
-; default_envs = esp32s3_devkitc
-; default_envs = esp32e_firebeetle2
-default_envs = 
-	esp32e_firebeetle2
-	esp32s3_devkitc
-	ci_validation_1
-	ci_validation_2
-
 [env:esp32e_firebeetle2]
-platform = https://github.com/pioarduino/platform-espressif32.git#54.03.20
-framework = arduino
 board = dfrobot_firebeetle2_esp32e
-lib_deps = ${common.lib_deps}
 build_flags = 
-	${common.build_flags}
+	${env.build_flags}
 	${common.build_flags_sensors}
-	${common.build_flags_wifi}
-	${common.build_flags_ha}
-extra_scripts = ${common.extra_scripts}
 
 [env:esp32s3_devkitc]
-platform = https://github.com/pioarduino/platform-espressif32.git#54.03.20
-framework = arduino
 board = esp32-s3-devkitc-1
-lib_deps = ${common.lib_deps}
 build_flags = 
-	${common.build_flags}
+	${env.build_flags}
 	${common.build_flags_sensors}
-	${common.build_flags_wifi}
-	${common.build_flags_ha}
-	${common.build_flags_usb_2_ports}
-extra_scripts = ${common.extra_scripts}
+	; These allow use of the USB/JTAG port which has less noise
+	; or funny characters but may need special/official drivers for it.
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
 
 ; The ci_validation_[1,2] configs exist to test that code works with only one sensor.
 ; Two environments to test that one works without the other.
 [env:ci_validation_1]
 extends = env:esp32e_firebeetle2
 build_flags = 
-	${common.build_flags}
-	${common.build_flags_wifi}
-	${common.build_flags_ha}
+	${env.build_flags}
 	-DSENSORS_LIGHT_PIN=A0
 
 [env:ci_validation_2]
 extends = env:esp32e_firebeetle2
 build_flags = 
-	${common.build_flags}
-	${common.build_flags_wifi}
-	${common.build_flags_ha}
+	${env.build_flags}
 	-DHAVE_AHT20=1
 
 ; To be restored once we actually create tests


### PR DESCRIPTION
- Move build flags and library dependencies into a shared [env] section for easier maintenance.
- Reduce duplication across board environments; now all inherit common settings.
- Remove legacy WiFi and Home Assistant build flag sections.
- Add comments and clarify USB/JTAG options for ESP32-S3.
- No functional changes to build or sensor logic; config is now easier to extend and audit.
