### PR TITLE
Update pio for ESP32 from 54.03.21 to 55.03.30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,10 @@ jobs:
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
 
-      - uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install PlatformIO
         run: pip install --upgrade platformio

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           build-mode: none
         - language: c-cpp
           build-mode: manual
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
@@ -78,13 +78,20 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      if: ${{ matrix.build-mode == 'manual'  && matrix.language == 'c-cpp' }}
+      with:
+        python-version: '3.13'
+
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above
     # to set the build mode to "manual" for that language. Then modify this step
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
+    - name: Build PlatformIO project
+      if: ${{ matrix.build-mode == 'manual'  && matrix.language == 'c-cpp' }}
       shell: bash
       run: |
         pip install --upgrade platformio && \

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,12 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-; The environments specified in default_envs are used when the current command does not have
-; a command override using --environment/-e options
-; Comment/uncomment, one of the lines to target just one which is easier/faster for local use.
 [platformio]
-; default_envs = esp32s3_devkitc
-; default_envs = esp32e_firebeetle2
 default_envs = 
 	esp32e_firebeetle2
 	esp32s3_devkitc
@@ -34,10 +29,9 @@ build_flags_sensors =
 	-DHAVE_AHT20=1
 	; -DHAVE_ENS160=1
 	-DCALIBRATION_TOGGLE_PIN=12
-build_flags_ha_host = \"192.168.8.100\"
 
 [env]
-platform = https://github.com/pioarduino/platform-espressif32.git#54.03.20
+platform = https://github.com/pioarduino/platform-espressif32.git#55.03.30
 framework = arduino
 lib_deps = 
 	beegee-tokyo/DHT sensor library for ESPx@1.19.0
@@ -64,8 +58,8 @@ build_flags =
 	; by default, we list all networks but if you want to skip this, uncomment the line below
 	; -DWIFI_SKIP_LIST_NETWORKS=1
 
-	; By default mDNS/Bonjour is used to discover IP, works in most cases, uncomment the line below to disable it and fix a value above
-	; -DHOME_ASSISTANT_MQTT_HOST=${common.build_flags_ha_host}
+	; By default mDNS/Bonjour is used to discover IP, works in most cases, uncomment the line below to disable it and fix a value
+	; -DHOME_ASSISTANT_MQTT_HOST=\"192.168.8.100\"
 	; Debugging for HA is enabled for easier visibility into what is happening in the library
 	-DARDUINOHA_DEBUG
 	-DHOME_ASSISTANT_MQTT_PORT=1883


### PR DESCRIPTION
Release notes: https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.30

Summary:
- Updates Arduino Core for ESP32 from 3.2.1 to 3.3.0 (details at https://github.com/espressif/arduino-esp32/releases/tag/3.3.0)
- Updated ESP-IDF from 5.4.0 to 5.5.0 (details at https://github.com/espressif/esp-idf/releases/tag/v5.5)