### PR TITLE
Bump platform-espressif32 from 55.03.30 to 55.03.32

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -31,7 +31,7 @@ build_flags_sensors =
 	-DCALIBRATION_TOGGLE_PIN=12
 
 [env]
-platform = https://github.com/pioarduino/platform-espressif32.git#55.03.30
+platform = https://github.com/pioarduino/platform-espressif32.git#55.03.32
 framework = arduino
 lib_deps = 
 	beegee-tokyo/DHT sensor library for ESPx@1.19.0


### PR DESCRIPTION
This updates `platform-espressif` from `55.03.30` to `55.03.32`. It updates the Arduino core to `v3.3.1` and ESP-IDF `5.5.1`. This closes #84 which makes it easier for anyone setting up.